### PR TITLE
issue #7 DBCLS共通ヘッダーの挿入

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     src="https://dbcls.rois.ac.jp/DBCLS-common-header-footer/v2/script/common-header-and-footer.js"
     style="display: block"
     id="common-header-and-footer__script"
-    data-width="auto"
+    data-width="512"
     data-header-menu-type="deployed"
     data-color="mono"
   ></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,9 @@
     src="https://dbcls.rois.ac.jp/DBCLS-common-header-footer/v2/script/common-header-and-footer.js"
     style="display: block"
     id="common-header-and-footer__script"
+    data-width="auto"
     data-header-menu-type="deployed"
+    data-color="mono"
   ></script>
   <div class="header">
     <div class="inner">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,13 @@
 </head>
 
 <body>
+  <script
+    type="text/javascript"
+    src="https://dbcls.rois.ac.jp/DBCLS-common-header-footer/v2/script/common-header-and-footer.js"
+    style="display: block"
+    id="common-header-and-footer__script"
+    data-header-menu-type="deployed"
+  ></script>
   <div class="header">
     <div class="inner">
       <div class="logo">


### PR DESCRIPTION
#7 

**対応内容**

- 標準的なDBCLS用共通ヘッダの導入しました。
　https://github.com/dbcls/website/tree/master/DBCLS-common-header-footer/v2

**確認確認**

- 画面起動でヘッダーにDBCLS用共通ヘッダが表示されること

**画面**
![スクリーンショット 2020-09-29 13 13 28](https://user-images.githubusercontent.com/39178089/94511928-ac3bad80-0255-11eb-85d1-b6f5d31aa731.png)

を

<img width="996" alt="スクリーンショット 2020-09-30 13 27 42" src="https://user-images.githubusercontent.com/39178089/94642984-be365280-0320-11eb-8217-809b5ee740ff.png">

に変更しました。