### PR TITLE
Fixed a bug that the dictionary cannot be selected when the dictionary name contains spaces

### DIFF
--- a/app/views/dictionaries/_dictionary_selection.html.erb
+++ b/app/views/dictionaries/_dictionary_selection.html.erb
@@ -77,15 +77,17 @@
 	}
 
 	function selectDictionary(dicname) {
-		$('#unselected_dictionaries > #dictionary_' + dicname).hide();
-		$('#unselected_dictionaries > #dictionary_' + dicname).attr('selected', true);
-		$('#selected_dictionaries > #dictionary_' + dicname).show();
+		var convertedDicname = dicname.replace(/ /g, '\\^');
+		$('#unselected_dictionaries > #dictionary_' + convertedDicname).hide();
+		$('#unselected_dictionaries > #dictionary_' + convertedDicname).attr('selected', true);
+		$('#selected_dictionaries > #dictionary_' + convertedDicname).show();
 	}
 
 	function unselectDictionary(dicname) {
-		$('#selected_dictionaries > #dictionary_' + dicname).hide();
-		$('#unselected_dictionaries > #dictionary_' + dicname).show();
-		$('#unselected_dictionaries > #dictionary_' + dicname).attr('selected', false);
+		var convertedDicname = dicname.replace(/ /g, '\\^');
+		$('#selected_dictionaries > #dictionary_' + convertedDicname).hide();
+		$('#unselected_dictionaries > #dictionary_' + convertedDicname).show();
+		$('#unselected_dictionaries > #dictionary_' + convertedDicname).attr('selected', false);
 	}
 
 	function setParamDics() {

--- a/app/views/dictionaries/_selected_dictionary.html.erb
+++ b/app/views/dictionaries/_selected_dictionary.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, id: 'dictionary_' + selected_dictionary, class: 'dictionary', name: selected_dictionary, style: 'display:none' do -%>
+<%= content_tag :div, id: "dictionary_#{selected_dictionary.gsub(/ /, '^')}", class: 'dictionary', name: selected_dictionary, style: 'display:none' do -%>
 	<%= link_to selected_dictionary, dictionary_path(selected_dictionary), class: 'name' %>
 	<%= content_tag :i, '', class:"fa fa-minus-circle", title: "unselect" %>
 <% end -%>

--- a/app/views/dictionaries/_unselected_dictionary.html.erb
+++ b/app/views/dictionaries/_unselected_dictionary.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, id: 'dictionary_' + unselected_dictionary, class: 'dictionary', name: unselected_dictionary, selected: false do -%>
+<%= content_tag :div, id: "dictionary_#{unselected_dictionary.gsub(/ /, '^')}", class: 'dictionary', name: unselected_dictionary, selected: false do -%>
 	<%= link_to unselected_dictionary, dictionary_path(unselected_dictionary), class: 'name' %>
 	<%= content_tag :i, '', class:"fa fa-plus-circle", title: "select" %>
 <% end -%>


### PR DESCRIPTION
## Purpose
When the name of the dictionary contains a space, there is a problem that the dictionary cannot be selected in Find IDs and Annotation, so fix it.

## Change List
- Added processing to convert spaces to caret("^") when generating the ID of the HTML element of the dictionary
- Changed so that the ID containing the caret can also be specified in the Jquery selector