### PR TITLE
Update web console gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
   gem 'guard-livereload', require: false
   gem 'faker'
   gem 'rails-erd'
-  gem 'web-console', '~> 2.0'
+  gem 'web-console'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,8 +69,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     bcrypt (3.1.16)
-    binding_of_caller (1.0.0)
-      debug_inspector (>= 0.0.1)
+    bindex (0.8.1)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -88,7 +87,6 @@ GEM
     connection_pool (2.2.3)
     crass (1.0.6)
     daemons (1.3.1)
-    debug_inspector (1.0.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
     delayed_job_active_record (4.1.5)
@@ -329,11 +327,11 @@ GEM
       public_suffix
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (4.1.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     webrick (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
@@ -379,7 +377,7 @@ DEPENDENCIES
   uglifier
   unicorn
   validate_url
-  web-console (~> 2.0)
+  web-console
   webrick
   wice_grid (~> 4.1)!
 


### PR DESCRIPTION
## Purpose
Fixed a problem that the error was not displayed properly in the development environment due to the version of web-console.

## Change Log
- update web-console to 4.1.0