### PR TITLE
Fix Zeitwerk::NameError in production environment

### DIFF
--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -36,7 +36,7 @@ class AnnotationController < ApplicationController
   def annotation_request
     targets = get_targets_from_json_body
     raise ArgumentError, "No text was supplied." unless targets.present?
-    raise AnnotationQueueOverflowError unless Job.number_of_tasks_to_go(:annotation) < 8
+    raise TextAnnotator::AnnotationQueueOverflowError unless Job.number_of_tasks_to_go(:annotation) < 8
 
     delayed_job = enqueue_job(targets)
     time_for_annotation = calc_time_for_annotation(targets)
@@ -50,7 +50,7 @@ class AnnotationController < ApplicationController
     respond_to do |format|
       format.any {render json: {message:e.message}, status: :bad_request}
     end
-  rescue AnnotationQueueOverflowError => e
+  rescue TextAnnotator::AnnotationQueueOverflowError => e
     respond_to do |format|
       format.any {render json: {message:"The annotation queue is full"}, status: :service_unavailable}
     end
@@ -65,7 +65,7 @@ class AnnotationController < ApplicationController
     target = get_target
 
     raise ArgumentError, "No text was supplied." unless target.present?
-    raise AnnotationQueueOverflowError unless Job.number_of_tasks_to_go(:annotation) < 8
+    raise TextAnnotator::AnnotationQueueOverflowError unless Job.number_of_tasks_to_go(:annotation) < 8
 
     delayed_job = enqueue_job(target)
     time_for_annotation = calc_time_for_annotation(target)
@@ -83,7 +83,7 @@ class AnnotationController < ApplicationController
     respond_to do |format|
       format.any {render json: {message:e.message}, status: :bad_request}
     end
-  rescue AnnotationQueueOverflowError => e
+  rescue TextAnnotator::AnnotationQueueOverflowError => e
     respond_to do |format|
       format.any {render json: {message:"The annotation queue is full"}, status: :service_unavailable}
     end

--- a/app/lib/text_annotator/annotation_queue_overflow_error.rb
+++ b/app/lib/text_annotator/annotation_queue_overflow_error.rb
@@ -1,1 +1,3 @@
-class AnnotationQueueOverflowError < StandardError; end
+class TextAnnotator
+  class AnnotationQueueOverflowError < StandardError; end
+end


### PR DESCRIPTION
## Purpose
Due to the effect of upgrading to Rails6, Zeitwerk :: NameError is now displayed when running `rails s` in the production environment. Fix `app/lib /text_annotator/annotation_queue_overflow_error.rb`.

## Change List
- Nested AnnotationQueueOverflowError class with TextAnnotator class