### PR TITLE
Remove dependencies on delayed job

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,8 +1,6 @@
 class ApplicationJob < ActiveJob::Base
   def create_job_record(name)
-    delayed_job = Delayed::Job.find(self.provider_job_id)
-    Job.create({name: name, queue_name: self.queue_name, dictionary_id: self.arguments[0].id, active_job_id: self.job_id, delayed_job_id: delayed_job.id,
-                registered_at: delayed_job.created_at})
+    Job.create({name: name, queue_name: self.queue_name, dictionary_id: self.arguments[0].id, active_job_id: self.job_id, registered_at: Time.current})
   end
 
   rescue_from(StandardError) do |exception|

--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -57,9 +57,7 @@ class TextAnnotationJob < ApplicationJob
   end
 
   def create_job_record(name, num_items, time)
-    delayed_job = Delayed::Job.find(self.provider_job_id)
-    Job.create({name: name, queue_name: self.queue_name, active_job_id: self.job_id, delayed_job_id: delayed_job.id,
-                registered_at: delayed_job.created_at, num_items: num_items, time: time})
+    Job.create({name: name, queue_name: self.queue_name, active_job_id: self.job_id, registered_at: Time.current, num_items: num_items, time: time})
   end
 
   before_perform do |active_job|

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -11,7 +11,7 @@ class Job < ApplicationRecord
   scope :to_delete, -> {where("name = 'Text annotation' AND ended_at < NOW() - INTERVAL '1 day'")}
 
   def self.time_for_tasks_to_go(queue_name)
-    Job.joins("JOIN delayed_jobs on jobs.delayed_job_id = delayed_jobs.id").where('delayed_jobs.queue' => queue_name, begun_at: nil).sum(:time)
+    Job.where(queue_name: queue_name, begun_at: nil).sum(:time)
   end
 
   def self.number_of_tasks_to_go(queue_name)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -15,7 +15,7 @@ class Job < ApplicationRecord
   end
 
   def self.number_of_tasks_to_go(queue_name)
-    Delayed::Job.where(queue: queue_name, attempts: 0).count
+    Job.where(queue_name: queue_name, begun_at: nil).count
   end
 
   def description_csv(host = nil)

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,4 +1,3 @@
 Delayed::Worker.max_attempts = 1
-Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_run_time = 7.days
 Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))

--- a/db/migrate/20210309061752_remove_delayed_job_id_column_to_jobs.rb
+++ b/db/migrate/20210309061752_remove_delayed_job_id_column_to_jobs.rb
@@ -1,0 +1,10 @@
+class RemoveDelayedJobIdColumnToJobs < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :jobs, :delayed_job_id, :bigint
+  end
+
+  def down
+    add_column :jobs, :delayed_job_id, :bigint
+    add_index :jobs, :delayed_job_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_09_025257) do
+ActiveRecord::Schema.define(version: 2021_03_09_061752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -84,7 +84,6 @@ ActiveRecord::Schema.define(version: 2021_03_09_025257) do
   create_table "jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.bigint "dictionary_id"
-    t.bigint "delayed_job_id"
     t.text "message"
     t.integer "num_items"
     t.integer "num_dones"
@@ -94,7 +93,6 @@ ActiveRecord::Schema.define(version: 2021_03_09_025257) do
     t.integer "time"
     t.string "active_job_id"
     t.string "queue_name"
-    t.index ["delayed_job_id"], name: "index_jobs_on_delayed_job_id"
     t.index ["dictionary_id"], name: "index_jobs_on_dictionary_id"
   end
 


### PR DESCRIPTION
## Purpose
Revise the code that depends on DelayedJob to make it easier to migrate background jobs.

## Change List
- Removed settings to leave failed delayed_jobs
- Removed delayed_job_id column to jobs table
- Revised code that depends on DelayedJob

## important point
- Dependencies in the job management screen have not been removed