### PR TITLE
Fix bug that message is not saved in job record

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,7 +7,8 @@ class ApplicationJob < ActiveJob::Base
 
   rescue_from(StandardError) do |exception|
     if @job
-      @job.message = "'" + exception.message + "'\n" + exception.backtrace.join("\n")
+      message = "'" + exception.message + "'\n" + exception.backtrace.join("\n")
+      @job.update(message: message, ended_at: Time.now)
     else
       raise exception
     end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,7 +7,7 @@ class ApplicationJob < ActiveJob::Base
 
   rescue_from(StandardError) do |exception|
     if @job
-      message = "'" + exception.message + "'\n" + exception.backtrace.join("\n")
+      message = "'#{exception.message}'\n#{exception.backtrace.join("\n")}"
       @job.update(message: message, ended_at: Time.now)
     else
       raise exception


### PR DESCRIPTION
## Purpose
In ActiveJob, after_perform callback is not called when the job fails, and message and ended_at are not saved in the Job record.
Revise to save message and ended_at in Job record even when job fails.

## Change List
- Revised to update Job record in rescue_from