### PR TITLE
Add activejob-cancel to remove dependency on DelayedJob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'bootsnap'
 gem 'language_list', '~> 1.2', '>= 1.2.1'
 gem 'string-similarity', '~> 2.1'
 gem 'webrick'
+gem 'activejob-cancel'
 
 group :development do
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
     activejob (6.1.3)
       activesupport (= 6.1.3)
       globalid (>= 0.3.6)
+    activejob-cancel (0.3.1)
+      activejob (>= 4.2.0)
+      activesupport (>= 4.2.0)
     activemodel (6.1.3)
       activesupport (= 6.1.3)
     activerecord (6.1.3)
@@ -345,6 +348,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activejob-cancel
   activerecord-import
   bootsnap
   clipboard-rails

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,7 @@
 class ApplicationJob < ActiveJob::Base
   def create_job_record(name)
     delayed_job = Delayed::Job.find(self.provider_job_id)
-    Job.create({name: name, dictionary_id: self.arguments[0].id, active_job_id: self.job_id, delayed_job_id: delayed_job.id,
+    Job.create({name: name, queue_name: self.queue_name, dictionary_id: self.arguments[0].id, active_job_id: self.job_id, delayed_job_id: delayed_job.id,
                 registered_at: delayed_job.created_at})
   end
 

--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -58,7 +58,7 @@ class TextAnnotationJob < ApplicationJob
 
   def create_job_record(name, num_items, time)
     delayed_job = Delayed::Job.find(self.provider_job_id)
-    Job.create({name: name, active_job_id: self.job_id, delayed_job_id: delayed_job.id,
+    Job.create({name: name, queue_name: self.queue_name, active_job_id: self.job_id, delayed_job_id: delayed_job.id,
                 registered_at: delayed_job.created_at, num_items: num_items, time: time})
   end
 

--- a/db/migrate/20210309025257_add_queue_name_column_to_jobs.rb
+++ b/db/migrate/20210309025257_add_queue_name_column_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddQueueNameColumnToJobs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :jobs, :queue_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_26_023309) do
+ActiveRecord::Schema.define(version: 2021_03_09_025257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2021_02_26_023309) do
     t.datetime "registered_at"
     t.integer "time"
     t.string "active_job_id"
+    t.string "queue_name"
     t.index ["delayed_job_id"], name: "index_jobs_on_delayed_job_id"
     t.index ["dictionary_id"], name: "index_jobs_on_dictionary_id"
   end


### PR DESCRIPTION
## Purpose
Add activejob-cancel to remove the dependency on DelayedJob from the `destroy_if_not_running` method of `job.rb`.

## Change List
- Added activejob-cancel gem
  - https://github.com/y-yagi/activejob-cancel
- Added queue_name column to jobs table
  - Because to identify the waiting job to be deleted by activejob-cancel
- Removed dependency on DelayedJob from destroy_if_not_running method