### PR TITLE
appleシリコン用対策

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   elasticsearch:
+    platform: linux/amd64
     build: ./elasticsearch
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9200/_cat/health" ]
@@ -8,8 +9,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    environment:
+      - discovery.type=single-node
 
   db:
+    platform: linux/amd64
     image: postgres
     environment:
       POSTGRES_PASSWORD: password
@@ -19,6 +23,7 @@ services:
     image: redis
 
   sidekiq:
+    platform: linux/amd64
     build: .
     command: bundle exec sidekiq -C config/sidekiq.yml
     volumes:
@@ -33,6 +38,7 @@ services:
       DB_PASSWORD: password
 
   web:
+    platform: linux/amd64
     build: .
     command: rails s -b '0.0.0.0'
     volumes:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+FROM elasticsearch:7.17.18
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-nori

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:6.5.3
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.18
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-nori


### PR DESCRIPTION
appleシリコンの環境でdocker開発環境を起動するための対策を実施しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 各コンテナのプラットフォームを`linux/amd64`に指定
- `elasticsearch `を7系の最新に更新
- `discovery.type=single-node`を設定してbootstrap checksでエラーになってしまうのを回避

## 参考文献
- https://github.com/elastic/elasticsearch/issues/69767
- https://hub.docker.com/_/elasticsearch/tags
- https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html