### PR TITLE
EntriesテーブルにTagカラムを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'rubyzip'
 gem 'webrick'
 gem 'activejob-cancel'
 gem 'sidekiq', '~> 7.0'
+gem 'select2-rails'
 
 group :development do
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    select2-rails (4.0.13)
     sidekiq (7.2.1)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
@@ -357,6 +358,7 @@ DEPENDENCIES
   ruby-stemmer
   rubyzip
   sass-rails
+  select2-rails
   sidekiq (~> 7.0)
   string-similarity (~> 2.1)
   test-unit

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,7 +22,6 @@
 document.addEventListener("DOMContentLoaded", function() {
   $('.js-searchable').select2({
     width: '100%',
-    allowClear: true,
-    containerCssClass: ':all:'
+    allowClear: true
   });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,12 @@
 //= require wice_grid
 //= require clipboard
 //= require_tree .
+//= require select2
+
+document.addEventListener("DOMContentLoaded", function() {
+  $('.js-searchable').select2({
+    width: '100%',
+    allowClear: true,
+    containerCssClass: ':all:'
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,4 +11,6 @@
  *= require_self
  *= require jquery-ui
  *= require_tree .
+ *= require select2
+ *= require select2-bootstrap
  */

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -25,7 +25,13 @@
     -%>
   </td>
   <td style="border-left-style: none">
-     <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
+    <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
+  </td>
+  <td style="border-right-style: none">
+    <%# TODO: add tag-search %>
+  </td>
+  <td style="border-left-style: none">
+    <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:'#'), title: 'search') -%>
   </td>
   <% if @dictionary.editable?(current_user) %>
     <td style="text-align:center">

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -29,6 +29,8 @@
     <col class="col_label">
     <col class="col_identifier">
     <col class="col_button">
+    <col class="col_tags">
+    <col class="col_button">
     <% if @dictionary.editable?(current_user) %>
       <col class="col_button">
     <% end %>
@@ -49,6 +51,10 @@
         	<%= submit_tag 'Search', class: 'button' -%>
     	  <% end -%>
       </th>
+      <th colspan="2">
+        Tags
+        <%# TODO: add tag-search %>
+      </th>
       <% if @dictionary.editable?(current_user) %>
         <th></th>
       <% end %>
@@ -62,6 +68,8 @@
       <col class="col_label">
       <col class="col_identifier">
       <col class="col_button">
+      <col class="col_tags">
+      <col class="col_button">
       <% if @dictionary.editable?(current_user) %>
         <col class="col_button">
       <% end %>
@@ -72,12 +80,12 @@
       <tr>
         <td style="border-style:none"></td>
         <td colspan="2" style="border-style:none"></td>
+        <td colspan="2" style="border-style:none"></td>
         <td style="text-align:center">
           <a title="remove selected entries" href="javascript:{}" onclick="document.getElementById('delete_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>
         </td>
       </tr>
     <% end %>
-
   </table>
 <% end %>
 
@@ -108,6 +116,7 @@
   <colgroup>
     <col class="col_label">
     <col class="col_identifier">
+    <col class="col_tags">
     <col class="col_button">
   </colgroup>
   <% if @dictionary.editable?(current_user) %>
@@ -119,12 +128,15 @@
         <td>
           <span><%= text_field_tag :identifier, nil, required: true, style: "box-sizing:content-box; width:90%" -%></span>
         </td>
+        <td>
+          <span><%= select_tag :tags, options_from_collection_for_select(Tag.where(dictionary_id: @dictionary.id), 'id', 'value'), multiple: true, class: 'js-searchable', style: "box-sizing:content-box; width:90%"  %></span>
+        </td>
         <td style="text-align:center">
           <a title="add" href="javascript:{}" onclick="document.getElementById('add_entry_form').submit(); return false;"><i class="fa fa-plus-square" aria-hidden="true"></i></a>
         </td>
       </tr>
     <% end %>
-  <% end %>  
+  <% end %>
 </table>
 
 <div class="table-control">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,9 @@
   <title>PubDictionaries</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag "application", :media => "all" %>
+  <!-- Styles for select2 -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css" />
   <%= yield :css -%>
   <%= javascript_include_tag "application" %>
   <%= yield :javascript -%>
@@ -22,7 +25,7 @@
     data-header-menu-type="deployed"
     data-color="mono"
   ></script>
- -->
+-->
   <div class="header">
     <div class="inner">
       <div class="logo">
@@ -74,5 +77,9 @@
     </div>
   </div>
   <%= yield :bottom_js -%>
+
+  <!-- Scripts for select2 -->
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.0/dist/jquery.slim.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.full.min.js"></script>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,9 +74,5 @@
     </div>
   </div>
   <%= yield :bottom_js -%>
-
-  <!-- Scripts for select2 -->
-  <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.0/dist/jquery.slim.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.full.min.js"></script>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,9 +5,6 @@
   <title>PubDictionaries</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag "application", :media => "all" %>
-  <!-- Styles for select2 -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css" />
   <%= yield :css -%>
   <%= javascript_include_tag "application" %>
   <%= yield :javascript -%>


### PR DESCRIPTION
#55 
EntriesテーブルへのTagカラム追加(select2導入とビューだけ)が完了しました。
ビューイメージも含め、認識違いがないか、ご確認よろしくお願いします。

## 実施したこと
- dictionary#showページのEntriesテーブルにタグ列を追加
- select2を導入し、entity登録行でそのdictionaryにつけられているタグを複数選択可能なところまで実装

## 実施していないこと
- entityの登録時にタグを紐づけるロジックは未実装
- 上記のため、entity作成後のtag表示やsearch機能は未実装

## 実行結果
実装前
![image](https://github.com/pubannotation/pubdictionaries/assets/149556430/915dd912-33f3-471c-9702-38ab0e1671ca)

実装後
[![Image from Gyazo](https://i.gyazo.com/fcb78ed6b71a2033bdd9a88129e9523b.gif)](https://gyazo.com/fcb78ed6b71a2033bdd9a88129e9523b)

