### PR TITLE
EntryにTagを登録

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,10 @@
 document.addEventListener("DOMContentLoaded", function() {
   $('.js-searchable').select2({
     width: '100%',
+    placeholder: {
+      id: "",
+      placeholder: ""
+    },
     allowClear: true
   });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,7 +10,7 @@
  *
  *= require_self
  *= require jquery-ui
- *= require_tree .
  *= require select2
  *= require select2-bootstrap
+ *= require_tree .
  */

--- a/app/assets/stylesheets/entries.scss
+++ b/app/assets/stylesheets/entries.scss
@@ -11,9 +11,9 @@ nav.pagination{
     margin: 0 0.2em;
   }
   .current{
-  	font-weight: bold;
+    font-weight: bold;
   }
-} 
+}
 
 table.entries {
 	table-layout: fixed;
@@ -21,7 +21,7 @@ table.entries {
   margin-top: 2px;
 
   .col_label {
-    width: 60%;
+    width: 50%;
   }
 
   .col_button {

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -41,6 +41,9 @@ class EntriesController < ApplicationController
 
 			entry = dictionary.new_entry(label, identifier, nil, Entry::MODE_WHITE, true)
 
+			tag_ids = params[:tags] || []
+			entry.tag_ids = tag_ids
+
 			message = if entry.save
 				dictionary.increment!(:entries_num)
 				# dictionary.update_tmp_sim_string_db

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -48,7 +48,7 @@ class Entry < ApplicationRecord
   }
 
   belongs_to :dictionary
-  has_many :entry_tags
+  has_many :entry_tags, dependent: :destroy
   has_many :tags, through: :entry_tags
 
   validates :label, presence: true

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -28,11 +28,11 @@
     <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
   </td>
   <td style="border-right-style: none">
-    <%# TODO: add tag-search %>
+    <% entry.tags.each do |tag| %>
+      <%= tag.value %>
+    <% end %>
   </td>
-  <td style="border-left-style: none">
-    <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:'#'), title: 'search') -%>
-  </td>
+  <td style="border-left-style: none"></td>
   <% if @dictionary.editable?(current_user) %>
     <td style="text-align:center">
       <% case entry.mode %>

--- a/db/migrate/20240226041211_add_cascade_delete_to_entry_tags.rb
+++ b/db/migrate/20240226041211_add_cascade_delete_to_entry_tags.rb
@@ -1,0 +1,7 @@
+class AddCascadeDeleteToEntryTags < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :entry_tags, :entries
+
+    add_foreign_key :entry_tags, :entries, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_20_081827) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_26_041211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -135,7 +135,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_20_081827) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  add_foreign_key "entry_tags", "entries"
+  add_foreign_key "entry_tags", "entries", on_delete: :cascade
   add_foreign_key "entry_tags", "tags"
   add_foreign_key "patterns", "dictionaries"
   add_foreign_key "tags", "dictionaries"


### PR DESCRIPTION
close #55 
EntryへのTag登録が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 前PRにて作ったselect2のフォームで、そのdictionaryに紐づいているtagを選択出来るようにし、＋ボタンクリックで選択したtagをentry-tagsテーブルにて紐づけ保存できるようにする
- タグは複数選択可能で、選択取りやめも可能
- 作成後のentryを削除するときに、entry-tagの紐づけも削除する

## 特記事項
- tag列を追加したことによって、表のバランスが悪くなったので、label列のwidth設定を60%→50%に狭めさせていただきました。
- 選択取りやめを実装するために`allowClear: true`を設定した場合にエラーになるバグがあるため、`placeholder`を空欄で設定しました。
参考：https://github.com/select2/select2/issues/3497#issuecomment-124122158

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/d9b64702-22b8-41d8-80e0-1492440ac5f1

