### PR TITLE
font-awesome-sassのアイコン修正

### DIFF
--- a/app/helpers/dictionaries_helper.rb
+++ b/app/helpers/dictionaries_helper.rb
@@ -66,7 +66,7 @@ module DictionariesHelper
 		end
 
 		link_to(
-			content_tag(:i, '', class:"fa fa-trash-o fa-lg"),
+			content_tag(:i, '', class:"fa-regular fa-trash-can fa-lg"),
 			empty_dictionary_entries_path(@dictionary, mode:mode),
 			title: title,
 			method: :put,

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -18,7 +18,7 @@ module UsersHelper
 	def login_with_google
 		<<-HEREDOC
 		<div style="display:inline-block; color:#fff">
-		  <div style="display:inline-block; margin: 0; padding:5px; background-color:#99f"><i class="fa fa-google" style="width:16px; height:15px"></i></div><div style="display:inline-block; margin:0; padding:5px; background-color:#88f"> Log in with Google</div>
+		  <div style="display:inline-block; margin: 0; padding:5px; background-color:#99f"><i class="fa-brands fa-google" style="width:16px; height:15px"></i></div><div style="display:inline-block; margin:0; padding:5px; background-color:#88f"> Log in with Google</div>
 		</div>
 		HEREDOC
   end

--- a/app/views/dictionaries/show_patterns.html.erb
+++ b/app/views/dictionaries/show_patterns.html.erb
@@ -7,7 +7,7 @@
 	<% if @dictionary.editable?(current_user) %>
 		<%=
 			link_to(
-				content_tag(:i, '', class:"fa fa-trash-o fa-lg"),
+				content_tag(:i, '', class:"fa-regular fa-trash-can fa-lg"),
 				empty_dictionary_patterns_path(@dictionary, mode:Entry::MODE_PATTERN),
 				title: 'Delete all the patterns',
 				method: :put,

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -39,7 +39,7 @@
       <% when Entry::MODE_GRAY %>
         <input type="checkbox" name="entry_id[]" id="entry_id_<%= entry.id %>" class="chkbox" value="<%= entry.id %>">
       <% when Entry::MODE_WHITE %>
-        <%= link_to('<i class="fa fa-trash-o" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Remove') %>
+        <%= link_to('<i class="fa-regular fa-trash-can" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Remove') %>
       <% when Entry::MODE_BLACK %>
         <%= link_to('<i class="fa fa-undo" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Back to gray') %>
       <% else %>

--- a/app/views/patterns/_pattern.html.erb
+++ b/app/views/patterns/_pattern.html.erb
@@ -23,7 +23,7 @@
 			<% end %>
 		</td>
 		<td class='for_button'>
-			<%= link_to('<i class="fa fa-trash-o" aria-hidden="true"></i>'.html_safe, dictionary_pattern_path(@dictionary, pattern), method: :delete, title: 'Remove') %>
+			<%= link_to('<i class="fa-regular fa-trash-can" aria-hidden="true"></i>'.html_safe, dictionary_pattern_path(@dictionary, pattern), method: :delete, title: 'Remove') %>
 		</td>
 	<% end %>
 </tr>


### PR DESCRIPTION
close #63
font-awesome-sassのアイコン修正が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- font-awesome-sass gemを使用しているアイコンが、問題なく表示出来ているか確認
　　→googleマーク1件、trash-boxマーク4件が表示できていなかった([結果詳細](https://github.com/pubannotation/pubdictionaries/issues/63#issuecomment-1963657081))
- 現在のバージョンに適合した記述に修正

## 修正前後のビュー
- login画面のgoogleマーク(現在コメントアウトされているが、念の為修正し、一時的にコメントを解除して確認しました)
修正前
![image](https://github.com/pubannotation/pubdictionaries/assets/149556430/88939cf9-1314-4774-9dba-dce3f56b0d10)
修正後
![image](https://github.com/pubannotation/pubdictionaries/assets/149556430/3e4f900c-641b-4b1f-a544-f5d5c4bbb540)

- trash-boxマーク
dictionary詳細画面
![image](https://github.com/pubannotation/pubdictionaries/assets/149556430/8f2365d4-9166-4546-84af-f1435067b167)

pattern画面
![image](https://github.com/pubannotation/pubdictionaries/assets/149556430/d269fa9f-e59c-40ac-8449-3ff9700afc10)
