### PR TITLE
使用中のTagを削除できなくする

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -225,10 +225,14 @@ class DictionariesController < ApplicationController
 			if @dictionary.update(dictionary_params)
 				db_loc_new = @dictionary.sim_string_db_dir
 				FileUtils.mv db_loc_old, db_loc_new unless db_loc_new == db_loc_old
-				@dictionary.update_tags(tag_list)
+				if @dictionary.update_tags(tag_list)
+					redirect_to @dictionary
+				else
+					flash[:alert] = @dictionary.errors.full_messages.to_sentence
+					redirect_back fallback_location: @dictionary
+				end
 			end
 
-			redirect_to @dictionary
 		rescue => e
 			redirect_back fallback_location: @dictionary, notice: e.message
 		end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -510,7 +510,7 @@ class Dictionary < ApplicationRecord
 		end
 
 		if tags_in_use.any?
-			errors.add(:base, "The following tags #{format_tags_for_error(tags_in_use)} are used. Please edit the entry before deleting.")
+			errors.add(:base, "The following tags #{format_tags_for_error(tags_in_use)} used. Please edit the entry before deleting.")
 			return false
 		end
 
@@ -617,7 +617,12 @@ class Dictionary < ApplicationRecord
 	end
 
 	def format_tags_for_error(tags_in_use)
-		return tags_in_use.join(" and ") if tags_in_use.length <= 2
-		"#{tags_in_use[0..-2].join(", ")} and #{tags_in_use.last}"
+		if tags_in_use.length == 1
+			return "#{tags_in_use.first} is"
+		elsif tags_in_use.length == 2
+			return "#{tags_in_use.join(" and ")} are"
+		else
+			"#{tags_in_use[0..-2].join(", ")} and #{tags_in_use.last} are"
+		end
 	end
 end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -492,22 +492,20 @@ class Dictionary < ApplicationRecord
 
   def update_tags(tag_list)
     current_tags = self.tags.to_a
-    current_tag_values = current_tags.map(&:value)
 
-    tags_to_add = tag_list - current_tag_values
-    tags_to_remove = current_tag_values - tag_list
+    tags_to_add = tag_list.reject { |tag_value| current_tags.any? { |t| t.value == tag_value } }
+    tags_to_remove = current_tags.reject { |tag| tag_list.include?(tag.value) }
 
     tags_to_add.each do |tag|
       self.tags.create!(value: tag)
     end
 
     tags_in_use = []
-    tags_to_remove.each do |tag_value|
-      tag = current_tags.find { |t| t.value == tag_value }
+    tags_to_remove.each do |tag|
       if tag.used_in_entries?
-        tags_in_use << tag_value
+        tags_in_use << tag.value
       else
-        self.tags.delete(tag)
+        tag.destroy
       end
     end
 

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -502,10 +502,10 @@ class Dictionary < ApplicationRecord
     tags_in_use = []
     tags_to_remove.each do |tag_value|
       tag = self.tags.find_by(value: tag_value)
-      if tag && tag.used_in_entries?
+      if tag.used_in_entries?
         tags_in_use << tag_value
       else
-        self.tags.delete(tag) if tag
+        self.tags.delete(tag)
       end
     end
 

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -499,22 +499,22 @@ class Dictionary < ApplicationRecord
       self.tags.create!(value: tag)
     end
 
-		tags_in_use = []
-		tags_to_remove.each do |tag_value|
-			tag = self.tags.find_by(value: tag_value)
-			if tag && tag.used_in_entries?
-				tags_in_use << tag_value
-			else
-				self.tags.delete(tag) if tag
-			end
-		end
+    tags_in_use = []
+    tags_to_remove.each do |tag_value|
+      tag = self.tags.find_by(value: tag_value)
+      if tag && tag.used_in_entries?
+        tags_in_use << tag_value
+      else
+        self.tags.delete(tag) if tag
+      end
+    end
 
-		if tags_in_use.any?
-			errors.add(:base, "The following tags #{format_tags_for_error(tags_in_use)} used. Please edit the entry before deleting.")
-			return false
-		end
+    if tags_in_use.any?
+      errors.add(:base, "The following tags #{format_tags_for_error(tags_in_use)} used. Please edit the entry before deleting.")
+      return false
+    end
 
-		true
+    true
   end
 
 	private
@@ -616,13 +616,13 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def format_tags_for_error(tags_in_use)
-		if tags_in_use.length == 1
-			return "#{tags_in_use.first} is"
-		elsif tags_in_use.length == 2
-			return "#{tags_in_use.join(" and ")} are"
-		else
-			"#{tags_in_use[0..-2].join(", ")} and #{tags_in_use.last} are"
-		end
-	end
+  def format_tags_for_error(tags_in_use)
+    if tags_in_use.length == 1
+      return "#{tags_in_use.first} is"
+    elsif tags_in_use.length == 2
+      return "#{tags_in_use.join(" and ")} are"
+    else
+      "#{tags_in_use[0..-2].join(", ")} and #{tags_in_use.last} are"
+    end
+  end
 end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -491,9 +491,11 @@ class Dictionary < ApplicationRecord
   end
 
   def update_tags(tag_list)
-    current_tags = self.tags.pluck(:value)
-    tags_to_add = tag_list - current_tags
-    tags_to_remove = current_tags - tag_list
+    current_tags = self.tags.to_a
+    current_tag_values = current_tags.map(&:value)
+
+    tags_to_add = tag_list - current_tag_values
+    tags_to_remove = current_tag_values - tag_list
 
     tags_to_add.each do |tag|
       self.tags.create!(value: tag)
@@ -501,7 +503,7 @@ class Dictionary < ApplicationRecord
 
     tags_in_use = []
     tags_to_remove.each do |tag_value|
-      tag = self.tags.find_by(value: tag_value)
+      tag = current_tags.find { |t| t.value == tag_value }
       if tag.used_in_entries?
         tags_in_use << tag_value
       else

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -510,7 +510,7 @@ class Dictionary < ApplicationRecord
     end
 
     if tags_in_use.any?
-      errors.add(:base, "The following tags #{format_tags_for_error(tags_in_use)} used. Please edit the entry before deleting.")
+      errors.add(:base, "The following tags #{tags_in_use.to_sentence} #{tags_in_use.length > 1 ? 'are' : 'is'} used. Please edit the entry before deleting.")
       return false
     end
 
@@ -615,14 +615,4 @@ class Dictionary < ApplicationRecord
 			Entry.method(:str_sim_jaccard_3gram)
 		end
 	end
-
-  def format_tags_for_error(tags_in_use)
-    if tags_in_use.length == 1
-      return "#{tags_in_use.first} is"
-    elsif tags_in_use.length == 2
-      return "#{tags_in_use.join(" and ")} are"
-    else
-      "#{tags_in_use[0..-2].join(", ")} and #{tags_in_use.last} are"
-    end
-  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -7,4 +7,8 @@ class Tag < ApplicationRecord
   validates_format_of :value, # because of to_param overriding.
                       :with => /\A[a-zA-Z_][a-zA-Z0-9_\- ()]*\z/,
                       :message => "should begin with an alphabet or underscore, and only contain alphanumeric letters, underscore, hyphen, space, or round brackets!"
+
+  def used_in_entries?
+    EntryTag.where(tag_id: self.id).exists?
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,6 +9,6 @@ class Tag < ApplicationRecord
                       :message => "should begin with an alphabet or underscore, and only contain alphanumeric letters, underscore, hyphen, space, or round brackets!"
 
   def used_in_entries?
-    EntryTag.where(tag_id: self.id).exists?
+    entry_tags.exists?
   end
 end


### PR DESCRIPTION
close #60 
使用中のTagを削除できなくするタスクが完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- dictionary#update時にtagを削除し、updateボタンを押した際、そのtagが使用されているときはエラーを表示して、タグは更新されないようにする

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/d0490d74-996e-4e54-8b48-0aeb5d6e58c2

