### PR TITLE
Entry::MODE_AUTO_EXPANDED追加

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -62,6 +62,8 @@ class DictionariesController < ApplicationController
 							[@dictionary.entries.active.simple_paginate(page, per), "Active"]
 						when Entry::MODE_CUSTOM
 							[@dictionary.entries.custom.simple_paginate(page, per), "Custom"]
+						when Entry::MODE_AUTO_EXPANDED
+							[@dictionary.entries.auto_expanded.simple_paginate(page, per), "Auto expanded"]
 						else
 							[@dictionary.entries.active.simple_paginate(page, per), "Active"]
 						end
@@ -93,6 +95,8 @@ class DictionariesController < ApplicationController
 							[@dictionary.entries.active, nil]
 						when Entry::MODE_CUSTOM
 							[@dictionary.entries.custom, "custom"]
+						when Entry::MODE_AUTO_EXPANDED
+							[@dictionary.entries.auto_expanded, "auto expanded"]
 						else
 							[@dictionary.entries.active, nil]
 						end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -176,6 +176,10 @@ class Dictionary < ApplicationRecord
 		entries.where(mode:Entry::MODE_BLACK).count
 	end
 
+  def num_auto_expanded
+    entries.where(mode:Entry::MODE_AUTO_EXPANDED).count
+  end
+
 	# turn a gray entry to white
 	def turn_to_white(entry)
 		raise "Only a gray entry can be turned to white" unless entry.mode == Entry::MODE_GRAY

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -164,21 +164,13 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def num_gray
-		entries_num - num_white
-	end
+  def num_gray = entries_num - num_white
 
-	def num_white
-		entries.where(mode:Entry::MODE_WHITE).count
-	end
+  def num_white = entries.white.count
 
-	def num_black
-		entries.where(mode:Entry::MODE_BLACK).count
-	end
+  def num_black = entries.black.count
 
-  def num_auto_expanded
-    entries.where(mode:Entry::MODE_AUTO_EXPANDED).count
-  end
+  def num_auto_expanded = entries.auto_expanded.count
 
 	# turn a gray entry to white
 	def turn_to_white(entry)

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -5,6 +5,7 @@ class Entry < ApplicationRecord
   MODE_ACTIVE = 3 # gray + white (for downloading)
   MODE_CUSTOM = 4 # white + black (for downloading)
   MODE_PATTERN = 5 # patterns (regular expressions)
+  MODE_AUTO_EXPANDED = 6
 
   include Elasticsearch::Model
 
@@ -59,6 +60,7 @@ class Entry < ApplicationRecord
   scope :black, -> {where(mode: Entry::MODE_BLACK)}
   scope :custom, -> {where(mode: [Entry::MODE_WHITE, Entry::MODE_BLACK])}
   scope :active, -> {where(mode: [Entry::MODE_GRAY, Entry::MODE_WHITE])}
+  scope :auto_expanded, -> {where(mode: Entry::MODE_AUTO_EXPANDED)}
 
   scope :simple_paginate, -> (page = 1, per = 15) {
     offset = (page - 1) * per

--- a/app/views/dictionaries/_counts.erb
+++ b/app/views/dictionaries/_counts.erb
@@ -5,6 +5,7 @@
         <col class="count_entries">
         <col class="count_entries">
         <col class="count_entries">
+        <col class="count_entries">
       </colgroup>
       <tr>
         <th colspan="2" class="active" style="border-style:none" title="<%= t('title.active') %>">
@@ -29,16 +30,21 @@
         <th class="black" title="<%= t('title.black') %>">
           <%= link_to_unless_current '# Black', params.permit(:mode).merge(mode: Entry::MODE_BLACK) %>
         </th>
+        <th class="auto_expanded" title="<%= t('title.auto_expanded') %>">
+          <%= link_to_unless_current '# Auto expanded', params.permit(:mode).merge(mode: Entry::MODE_AUTO_EXPANDED) %>
+        </th>
       </tr>
       <tr>
         <td style="text-align: right"><%= number_with_delimiter(@dictionary.num_gray, :delimiter => ',') %></td>
         <td style="text-align: right"><%= @dictionary.num_white %></td>
         <td style="text-align: right"><%= @dictionary.num_black %></td>
+        <td style="text-align: right"><%= @dictionary.num_auto_expanded %></td>
       </tr>
       <tr>
         <th><%= delete_entries_helper(Entry::MODE_GRAY) %></th>
         <th><%= delete_entries_helper(Entry::MODE_WHITE) %></th>
         <th><%= delete_entries_helper(Entry::MODE_BLACK) %></th>
+        <th><%= delete_entries_helper(Entry::MODE_AUTO_EXPANDED) %></th>
       </tr>
     </table>
   <% else %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -4,6 +4,7 @@
       when Entry::MODE_GRAY then "entry gray"
       when Entry::MODE_WHITE then "entry white"
       when Entry::MODE_BLACK then "entry black"
+      when Entry::MODE_AUTO_EXPANDED then "entry auto expanded"
       else "entry"
     end
   else
@@ -42,6 +43,9 @@
         <%= link_to('<i class="fa-regular fa-trash-can" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Remove') %>
       <% when Entry::MODE_BLACK %>
         <%= link_to('<i class="fa fa-undo" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Back to gray') %>
+      <% when Entry::MODE_AUTO_EXPANDED %>
+        <%# MUST: set correct icon-button, link and title %>
+        <%= link_to('<i class="fa fa-undo" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: '') %>
       <% else %>
       <% end %>
     </td>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -11,6 +11,8 @@
       t('title.active')
     when 'Custom'
       t('title.custom')
+    when 'Auto expanded'
+      t('title.auto_expanded')
     end
   %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,3 +36,4 @@ en:
     black: "Black entries: the entries that have been manually removed. These entries will not be used during annotation or lookup."
     active: "Active entries: gray entries + white entries. These entries will be used for annotation and lookup."
     custom: "Custom entries: white entries + black entries. These entries are those that have been manually added or removed."
+    auto_expanded: "Auto expanded entries: " # MUST: add description of auto_expanded entries


### PR DESCRIPTION
close #65 
Entry::MODE_AUTO_EXPANDED追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Entry::MODEに`Entry::MODE_AUTO_EXPANDED`を追加
- モード追加に伴い、モードごとで条件わけしている場面などに`Entry::MODE_AUTO_EXPANDED`の場合の分岐を追加
- 仮で、Dictionary詳細画面右上のモード別entryカウントのビュー表示を追加

## 実施していないこと（コメントに`MUST`で残しています）
- 各モードのタイトルにカーソルを合わせると表示される説明書きは、詳細不明のため未記載(config/locales/en.yml)
- `# モード`をクリックすると、そのモードのentryが表に表示されるが、その表示条件や削除、モード遷移条件など不明のため、一旦仮で記載しているが修正が必要(app/views/entries/_entry.html.erb)

## 仮ビュー

https://github.com/pubannotation/pubdictionaries/assets/149556430/50b964c1-c506-4616-86f1-cf956a5e4494
