### PR TITLE
Entryへのscoreカラム追加

### DIFF
--- a/app/assets/stylesheets/entries.scss
+++ b/app/assets/stylesheets/entries.scss
@@ -24,6 +24,10 @@ table.entries {
     width: 30%;
   }
 
+  .col_score {
+    width: 50px;
+  }
+
   .col_button {
     width: 30px;
   }

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -54,6 +54,7 @@ class Entry < ApplicationRecord
 
   validates :label, presence: true
   validates :identifier, presence: true
+  validates :score, numericality: { greater_than_or_equal_to: 0, less_than: 1 }, allow_nil: true
 
   scope :gray, -> {where(mode: Entry::MODE_GRAY)}
   scope :white, -> {where(mode: Entry::MODE_WHITE)}

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -34,6 +34,11 @@
     <% end %>
   </td>
   <td style="border-left-style: none"></td>
+  <% if entry.mode == Entry::MODE_AUTO_EXPANDED %>
+    <td style="border-right-style: none">
+      <%= entry.score %>
+    </td>
+  <% end %>
   <% if @dictionary.editable?(current_user) %>
     <td style="text-align:center">
       <% case entry.mode %>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -33,6 +33,9 @@
     <col class="col_button">
     <col class="col_tags">
     <col class="col_button">
+    <% if @type_entries == 'Auto expanded' %>
+      <col class="col_score">
+    <% end %>
     <% if @dictionary.editable?(current_user) %>
       <col class="col_button">
     <% end %>
@@ -66,6 +69,9 @@
             <%= submit_tag 'Search', class: 'button' -%>
           <% end -%>
       </th>
+      <% if @type_entries == 'Auto expanded' %>
+        <th>Score</th>
+      <% end %>
       <% if @dictionary.editable?(current_user) %>
         <th></th>
       <% end %>
@@ -81,6 +87,9 @@
       <col class="col_button">
       <col class="col_tags">
       <col class="col_button">
+      <% if @type_entries == 'Auto expanded' %>
+        <col class="col_score">
+      <% end %>
       <% if @dictionary.editable?(current_user) %>
         <col class="col_button">
       <% end %>
@@ -128,6 +137,9 @@
     <col class="col_label">
     <col class="col_identifier">
     <col class="col_tags">
+    <% if @type_entries == 'Auto expanded' %>
+      <col class="col_score">
+    <% end %>
     <col class="col_button">
   </colgroup>
   <% if @dictionary.editable?(current_user) %>
@@ -142,6 +154,9 @@
         <td>
           <span><%= select_tag :tags, options_from_collection_for_select(Tag.where(dictionary_id: @dictionary.id), 'id', 'value'), multiple: true, class: 'js-searchable', style: "box-sizing:content-box; width:100%"  %></span>
         </td>
+        <% if @type_entries == 'Auto expanded' %>
+          <td></td>
+        <% end %>
         <td style="text-align:center">
           <a title="add" href="javascript:{}" onclick="document.getElementById('add_entry_form').submit(); return false;"><i class="fa fa-plus-square" aria-hidden="true"></i></a>
         </td>

--- a/db/migrate/20240301042744_add_score_to_entries.rb
+++ b/db/migrate/20240301042744_add_score_to_entries.rb
@@ -1,0 +1,5 @@
+class AddScoreToEntries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :entries, :score, :decimal, precision: 5, scale: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_26_041211) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_01_042744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_26_041211) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "dirty", default: false
+    t.decimal "score", precision: 5, scale: 4
     t.index ["dictionary_id", "label", "identifier"], name: "index_entries_on_dictionary_id_and_label_and_identifier"
     t.index ["dictionary_id"], name: "index_entries_on_dictionary_id"
     t.index ["dirty"], name: "index_entries_on_dirty"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,9 +27,9 @@ entry_items = [
   { mode: Entry::MODE_WHITE, label: "White Mode Entry5", identifier: "4", tags: [] },
   { mode: Entry::MODE_BLACK, label: "Black Mode Entry", identifier: "3", tags: [seed_tags.second, seed_tags.third] },
   { mode: Entry::MODE_BLACK, label: "Black Mode Entry2", identifier: "1", tags: [] },
-  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry", identifier: "1", tags: [seed_tags.second] },
-  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry2", identifier: "1", tags: [] },
-  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry3", identifier: "3", tags: seed_tags }
+  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry", identifier: "1", tags: [seed_tags.second], score: 0.5 },
+  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry2", identifier: "1", tags: [], score: 0.9999 },
+  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry3", identifier: "3", tags: seed_tags, score: 0 },
 ]
 
 entry_items.each do |entry_def|
@@ -37,6 +37,7 @@ entry_items.each do |entry_def|
     label: entry_def[:label],
     identifier: entry_def[:identifier],
     mode: entry_def[:mode],
+    score: entry_def[:score]
   )
 
   entry.tags = entry_def[:tags]


### PR DESCRIPTION
close #69 
Entryへのscoreカラム追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Entryテーブルへscoreカラムを追加(任意、0以上1未満、小数点以下4位まで許容)
- seedデータの方も、Entry::MODE_AUTO_EXPANDEDモードのentryにはscoreを追加設定
- 一旦登録したscoreが見れるように、`#Auto Expanded`での絞り込みページにscoreを表示する列を追加

## 実施していないこと
- scoreはユーザーが直接入力しない認識なので、入力フォームは作っていません
- 現在、`#Auto Expanded`での絞り込みページ以外にはscore列は見れないようにしています。必要であれば次issueで対応いたします。

## `#Auto Expanded`での絞り込みページ
![image](https://github.com/pubannotation/pubdictionaries/assets/149556430/cf262fc2-f677-4ec2-952f-248c71ff0242)
