### PR TITLE
Dictionary詳細画面の改修

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -94,7 +94,7 @@ class EntriesController < ApplicationController
 
 			raise ArgumentError, "No entry to be deleted is selected" unless params[:entry_id].present?
 
-			entries = params[:entry_id].collect{|id| Entry.find(id)}
+			entries = Entry.where(id: params[:entry_id])
 			entries.each{|entry| entry.be_black!}
 			dictionary.update_attribute(:entries_num, dictionary.entries_num - entries.count)
 		rescue => e
@@ -137,8 +137,8 @@ class EntriesController < ApplicationController
 
 			raise ArgumentError, "No entry to be deleted is selected" unless params[:entry_id].present?
 
-			entries = params[:entry_id].collect{|id| Entry.find(id)}
-			entries.each{|entry| entry.destroy}
+			entries = Entry.where(id: params[:entry_id])
+			entries.destroy_all
 		rescue => e
 			message = e.message
 		end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -87,7 +87,7 @@ class EntriesController < ApplicationController
 		end
 	end
 
-	def destroy
+	def switch_to_black
 		begin
 			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
 			raise ArgumentError, "Could not find the dictionary" if dictionary.nil?
@@ -106,7 +106,7 @@ class EntriesController < ApplicationController
 		end
 	end
 
-	def destroy_entries
+	def switch_to_black_entries
 		begin
 			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
 			raise ArgumentError, "Could not find the dictionary" if dictionary.nil?

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -148,4 +148,22 @@ class EntriesController < ApplicationController
 			}
 		end
 	end
+
+	def destroy_entries
+		begin
+			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
+			raise ArgumentError, "Could not find the dictionary" if dictionary.nil?
+
+			raise ArgumentError, "No entry to be deleted is selected" unless params[:entry_id].present?
+
+			entries = params[:entry_id].collect{|id| Entry.find(id)}
+			entries.each{|entry| entry.destroy}
+		rescue => e
+			message = e.message
+		end
+
+		respond_to do |format|
+			format.html{ redirect_back fallback_location: root_path, notice: message }
+		end
+	end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -87,25 +87,6 @@ class EntriesController < ApplicationController
 		end
 	end
 
-	def switch_to_black
-		begin
-			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
-			raise ArgumentError, "Could not find the dictionary" if dictionary.nil?
-
-			entry = Entry.find(params[:id])
-			raise ArgumentError, "Could not find the entry" if entry.nil?
-
-			entry.be_black!
-			dictionary.decrement!(:entries_num)
-		rescue => e
-			message = e.message
-		end
-
-		respond_to do |format|
-			format.html{ redirect_back fallback_location: root_path, notice: message }
-		end
-	end
-
 	def switch_to_black_entries
 		begin
 			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -137,8 +137,7 @@ class EntriesController < ApplicationController
 
 			raise ArgumentError, "No entry to be deleted is selected" unless params[:entry_id].present?
 
-			entries = Entry.where(id: params[:entry_id])
-			entries.destroy_all
+			Entry.where(id: params[:entry_id]).destroy_all
 		rescue => e
 			message = e.message
 		end

--- a/app/helpers/dictionaries_helper.rb
+++ b/app/helpers/dictionaries_helper.rb
@@ -51,7 +51,7 @@ module DictionariesHelper
 	end
 
 	def delete_entries_helper(mode = nil)
-		mode_to_s = mode.nil? ? '' : ['gray', 'white', 'black', 'pattern'][mode]
+		mode_to_s = mode.nil? ? '' : ['gray', 'white', 'black', 'pattern', 'auto expanded'][mode]
 
 		title = if mode == Entry::MODE_BLACK
 			"Turn all the black entries to gray"

--- a/app/helpers/dictionaries_helper.rb
+++ b/app/helpers/dictionaries_helper.rb
@@ -51,7 +51,7 @@ module DictionariesHelper
 	end
 
 	def delete_entries_helper(mode = nil)
-		mode_to_s = mode.nil? ? '' : ['gray', 'white', 'black', 'pattern', 'auto expanded'][mode]
+		mode_to_s = Entry.mode_to_s(mode)
 
 		title = if mode == Entry::MODE_BLACK
 			"Turn all the black entries to gray"

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -235,20 +235,20 @@ class Dictionary < ApplicationRecord
 		case mode
 		when nil
 			transaction do
-				entries.delete_all
+				entries.destroy_all
 				update_attribute(:entries_num, 0)
 				clean_sim_string_db
 			end
 		when Entry::MODE_GRAY
 			_num_white = num_white
 			transaction do
-				entries.gray.delete_all
+				entries.gray.destroy_all
 				update_attribute(:entries_num, _num_white)
 			end
 		when Entry::MODE_WHITE
 			_num_gray = num_gray
 			transaction do
-				entries.white.delete_all
+				entries.white.destroy_all
 				update_attribute(:entries_num, _num_gray)
 			end
 		when Entry::MODE_BLACK
@@ -257,7 +257,7 @@ class Dictionary < ApplicationRecord
 			end
 		when Entry::MODE_AUTO_EXPANDED
 			transaction do
-				entries.auto_expanded.delete_all
+				entries.auto_expanded.destroy_all
 			end
 		else
 			raise ArgumentError, "Unexpected mode: #{mode}"

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -255,6 +255,10 @@ class Dictionary < ApplicationRecord
 			transaction do
 				entries.black.each{|e| cancel_black(e)}
 			end
+		when Entry::MODE_AUTO_EXPANDED
+			transaction do
+				entries.auto_expanded.delete_all
+			end
 		else
 			raise ArgumentError, "Unexpected mode: #{mode}"
 		end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -79,6 +79,10 @@ class Entry < ApplicationRecord
     }
   end
 
+  def self.mode_to_s(mode)
+    mode.nil? ? '' : ['gray', 'white', 'black', 'active', 'custom', 'pattern', 'auto expanded'][mode]
+  end
+
   def self.as_tsv
     CSV.generate(col_sep: "\t") do |tsv|
       tsv << ['#label', :id]

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -61,7 +61,7 @@ class Entry < ApplicationRecord
   scope :black, -> {where(mode: Entry::MODE_BLACK)}
   scope :custom, -> {where(mode: [Entry::MODE_WHITE, Entry::MODE_BLACK])}
   scope :active, -> {where(mode: [Entry::MODE_GRAY, Entry::MODE_WHITE])}
-  scope :auto_expanded, -> {where(mode: Entry::MODE_AUTO_EXPANDED)}
+  scope :auto_expanded, -> {where(mode: Entry::MODE_AUTO_EXPANDED).order(score: :desc)}
 
   scope :simple_paginate, -> (page = 1, per = 15) {
     offset = (page - 1) * per

--- a/app/views/entries/_colgroup.erb
+++ b/app/views/entries/_colgroup.erb
@@ -1,0 +1,13 @@
+  <colgroup>
+    <col class="col_label">
+    <col class="col_identifier">
+    <col class="col_button">
+    <col class="col_tags">
+    <col class="col_button">
+    <% if type_entries == 'Auto expanded' %>
+      <col class="col_score">
+    <% end %>
+    <% if dictionary.editable?(current_user) %>
+      <col class="col_button">
+    <% end %>
+  </colgroup>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -49,8 +49,7 @@
       <% when Entry::MODE_BLACK %>
         <%= link_to('<i class="fa fa-undo" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Back to gray') %>
       <% when Entry::MODE_AUTO_EXPANDED %>
-        <%# MUST: set correct icon-button, link and title %>
-        <%= link_to('<i class="fa fa-undo" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: '') %>
+        <input type="checkbox" name="entry_id[]" id="entry_id_<%= entry.id %>" class="chkbox" value="<%= entry.id %>">
       <% else %>
       <% end %>
     </td>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -79,7 +79,7 @@
   </thead>
 </table>
 
-<%= form_tag(dictionary_entries_path(@dictionary), method: :delete, id: "delete_entries_form") do %>
+<%= form_tag(switch_entries_dictionary_entries_path(@dictionary), method: :put, id: "switch_entries_form") do %>
   <table class="entries" style="margin-top:0; margin-bottom:0">
     <colgroup>
       <col class="col_label">
@@ -102,7 +102,7 @@
         <td colspan="2" style="border-style:none"></td>
         <td colspan="2" style="border-style:none"></td>
         <td style="text-align:center">
-          <a title="remove selected entries" href="javascript:{}" onclick="document.getElementById('delete_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>
+          <a title="switch selected entries to black" href="javascript:{}" onclick="document.getElementById('switch_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>
         </td>
       </tr>
     <% end %>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -79,33 +79,36 @@
   </thead>
 </table>
 
-<%= form_tag(switch_entries_dictionary_entries_path(@dictionary), method: :put, id: "switch_entries_form") do %>
-  <table class="entries" style="margin-top:0; margin-bottom:0">
-    <colgroup>
-      <col class="col_label">
-      <col class="col_identifier">
-      <col class="col_button">
-      <col class="col_tags">
-      <col class="col_button">
-      <% if @type_entries == 'Auto expanded' %>
-        <col class="col_score">
-      <% end %>
-      <% if @dictionary.editable?(current_user) %>
-        <col class="col_button">
-      <% end %>
-    </colgroup>
-    <%= render partial: "entries/entry", collection: @entries -%>
+<% if @dictionary.editable?(current_user) %>
+  <% form_action_path = ['Gray', 'Active'].include?(@type_entries) ? switch_entries_dictionary_entries_path(@dictionary) : dictionary_entries_path(@dictionary) %>
+  <% form_method = ['Gray', 'Active'].include?(@type_entries) ? :put : :delete %>
+  <%= form_tag(form_action_path, method: form_method, id: "#{form_method == :put ? 'switch_entries_form' : 'delete_entries_form'}") do %>
 
-    <% if @dictionary.editable?(current_user) && ['Gray', 'Active'].include?(@type_entries) %>
+    <table class="entries" style="margin-top:0; margin-bottom:0">
+      <%= render 'entries/colgroup', type_entries: @type_entries, dictionary: @dictionary %>
+      <%= render partial: "entries/entry", collection: @entries -%>
+
       <tr>
         <td style="border-style:none"></td>
         <td colspan="2" style="border-style:none"></td>
         <td colspan="2" style="border-style:none"></td>
-        <td style="text-align:center">
-          <a title="switch selected entries to black" href="javascript:{}" onclick="document.getElementById('switch_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>
-        </td>
+        <% if ['Gray', 'Active'].include?(@type_entries) %>
+          <td style="text-align:center">
+            <a title="switch selected entries to black" href="javascript:{}" onclick="document.getElementById('switch_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>
+          </td>
+        <% elsif ['Auto expanded'].include?(@type_entries) %>
+          <td style="border-style:none"></td>
+          <td style="text-align:center">
+            <a title="remove selected entries" href="javascript:{}" onclick="document.getElementById('delete_entries_form').submit(); return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
+          </td>
+        <% end %>
       </tr>
-    <% end %>
+    </table>
+  <% end %>
+<% else %>
+  <table class="entries" style="margin-top:0; margin-bottom:0">
+    <%= render 'entries/colgroup', type_entries: @type_entries, dictionary: @dictionary %>
+    <%= render partial: "entries/entry", collection: @entries -%>
   </table>
 <% end %>
 

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -99,7 +99,7 @@
         <% elsif ['Auto expanded'].include?(@type_entries) %>
           <td style="border-style:none"></td>
           <td style="text-align:center">
-            <a title="remove selected entries" href="javascript:{}" onclick="document.getElementById('delete_entries_form').submit(); return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
+            <a title="remove selected entries" href="javascript:{}" onclick="if(confirm('Are you sure to remove selected entries?')) { document.getElementById('delete_entries_form').submit(); } return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
           </td>
         <% end %>
       </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
         put 'empty', to: 'dictionaries#empty'
         post 'tsv', to: 'entries#upload_tsv'
         put 'switch_entries', to: 'entries#switch_to_black_entries'
+        delete '/', to:'entries#destroy_entries'
       end
 
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,10 +60,11 @@ Rails.application.routes.draw do
       collection do
         put 'empty', to: 'dictionaries#empty'
         post 'tsv', to: 'entries#upload_tsv'
-        delete '/', to: 'entries#destroy_entries'
+        put 'switch_entries', to: 'entries#switch_to_black_entries'
       end
 
       member do
+        put 'switch', to: 'entries#switch_to_black'
         put 'undo', to: "entries#undo"
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,6 @@ Rails.application.routes.draw do
       end
 
       member do
-        put 'switch', to: 'entries#switch_to_black'
         put 'undo', to: "entries#undo"
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
         put 'empty', to: 'dictionaries#empty'
         post 'tsv', to: 'entries#upload_tsv'
         put 'switch_entries', to: 'entries#switch_to_black_entries'
-        delete '/', to:'entries#destroy_entries'
+        delete '/', to: 'entries#destroy_entries'
       end
 
       member do


### PR DESCRIPTION
close #77 
Dictionary詳細画面の改修が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Grayモード→Blackモードへのモード切替を`switch_to_black`というメソッド名に変更（動作は同じ）
- Auto expendedモードの絞り込み画面では、Scoreの降順で表示するように設定
- Auto expendedモードの絞り込み画面にて、チェックボックスを設置し、ゴミ箱マークを押下したら、チェックされているentryを削除(blackでもなく、DBから完全削除)、削除前にアラートで確認
- 右上の#Auto expandedのゴミ箱マークをクリックしたら、Auto expandedモードのentryを全削除する

## 実施していないこと
- Auto expendedモードは現状entries_numに含まれていないため、削除などをしても値のインクリメント等の動作はいれていない。必要があればentries_num自体の見直しの際に対応する予定。

## 実行結果
Gray→Blackへのモード切替

https://github.com/pubannotation/pubdictionaries/assets/149556430/cbc7410c-57e1-46de-ae30-441873bedf96


Auto expandedのチェックボックスからの削除

https://github.com/pubannotation/pubdictionaries/assets/149556430/22eaef8e-b164-49fc-a679-3241c38e757c


Auto expandedの全削除

https://github.com/pubannotation/pubdictionaries/assets/149556430/6ce3e1d9-7b7b-46ef-b8a0-d263c64dcb97


