### PR TITLE
entries_num見直し

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -138,6 +138,7 @@ class EntriesController < ApplicationController
 			raise ArgumentError, "No entry to be deleted is selected" unless params[:entry_id].present?
 
 			Entry.where(id: params[:entry_id]).destroy_all
+			dictionary.update_entries_num
 		rescue => e
 			message = e.message
 		end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -45,7 +45,7 @@ class EntriesController < ApplicationController
 			entry.tag_ids = tag_ids
 
 			message = if entry.save
-				dictionary.increment!(:entries_num)
+				dictionary.update_entries_num
 				# dictionary.update_tmp_sim_string_db
 				"The white entry #{entry} was created."
 			else
@@ -96,7 +96,7 @@ class EntriesController < ApplicationController
 
 			entries = Entry.where(id: params[:entry_id])
 			entries.each{|entry| entry.be_black!}
-			dictionary.update_attribute(:entries_num, dictionary.entries_num - entries.count)
+			dictionary.update_entries_num
 		rescue => e
 			message = e.message
 		end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -164,7 +164,12 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-  def num_gray = entries_num - num_white
+  def update_entries_num
+		non_black_num = entries.where.not(mode: Entry::MODE_BLACK).count
+		update(entries_num: non_black_num)
+  end
+
+  def num_gray = entries.gray.count
 
   def num_white = entries.white.count
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,6 +44,4 @@ entry_items.each do |entry_def|
 end
 
 # set entries_num
-num_gray = dictionary.entries.where(mode: Entry::MODE_GRAY).count
-num_white = dictionary.entries.where(mode: Entry::MODE_WHITE).count
-dictionary.update(entries_num: (num_gray + num_white))
+dictionary.update_entries_num


### PR DESCRIPTION
close #79 
entries_num見直しが完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- `update_entries_num `メソッドを定義、entryの手動追加時とdictionery詳細画面(show)時にentries_numを更新するように変更
- `entries_num`を直接incrementなどしていた部分を`update_entries_num `メソッドに置き換え
- 置き換えた各所に関連する動作が問題なく動作することを確認

## 実行結果
`entries_num`が確認しづらいので、右上のカウント表の下にデバッグ用表示をして確認しました。

https://github.com/pubannotation/pubdictionaries/assets/149556430/85355ca1-ce35-4b06-920e-9d9776ad615a

