### PR TITLE
EntryModeクラス作成

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -52,17 +52,17 @@ class DictionariesController < ApplicationController
 				else
 					if params[:mode].present?
 						case params[:mode].to_i
-						when Entry::MODE_WHITE
+						when EntryMode::WHITE
 							[@dictionary.entries.white.simple_paginate(page, per), "White"]
-						when Entry::MODE_BLACK
+						when EntryMode::BLACK
 							[@dictionary.entries.black.simple_paginate(page, per), "Black"]
-						when Entry::MODE_GRAY
+						when EntryMode::GRAY
 							[@dictionary.entries.gray.simple_paginate(page, per), "Gray"]
-						when Entry::MODE_ACTIVE
+						when EntryMode::ACTIVE
 							[@dictionary.entries.active.simple_paginate(page, per), "Active"]
-						when Entry::MODE_CUSTOM
+						when EntryMode::CUSTOM
 							[@dictionary.entries.custom.simple_paginate(page, per), "Custom"]
-						when Entry::MODE_AUTO_EXPANDED
+						when EntryMode::AUTO_EXPANDED
 							[@dictionary.entries.auto_expanded.simple_paginate(page, per), "Auto expanded"]
 						else
 							[@dictionary.entries.active.simple_paginate(page, per), "Active"]
@@ -85,17 +85,17 @@ class DictionariesController < ApplicationController
 				else
 					if params[:mode].present?
 						case params[:mode].to_i
-						when Entry::MODE_WHITE
+						when EntryMode::WHITE
 							[@dictionary.entries.added, "white"]
-						when Entry::MODE_BLACK
+						when EntryMode::BLACK
 							[@dictionary.entries.deleted, "black"]
-						when Entry::MODE_GRAY
+						when EntryMode::GRAY
 							[@dictionary.entries.gray, "gray"]
-						when Entry::MODE_ACTIVE
+						when EntryMode::ACTIVE
 							[@dictionary.entries.active, nil]
-						when Entry::MODE_CUSTOM
+						when EntryMode::CUSTOM
 							[@dictionary.entries.custom, "custom"]
-						when Entry::MODE_AUTO_EXPANDED
+						when EntryMode::AUTO_EXPANDED
 							[@dictionary.entries.auto_expanded, "auto expanded"]
 						else
 							[@dictionary.entries.active, nil]
@@ -107,7 +107,7 @@ class DictionariesController < ApplicationController
 
 				filename = @dictionary.name
 				filename += '_' + suffix if suffix
-				if params[:mode].to_i == Entry::MODE_CUSTOM
+				if params[:mode].to_i == EntryMode::CUSTOM
 					send_data entries.as_tsv_v,  filename: "#{filename}.tsv", type: :tsv
 				else
 					send_data entries.as_tsv,  filename: "#{filename}.tsv", type: :tsv
@@ -315,7 +315,7 @@ class DictionariesController < ApplicationController
 
 			mode = params[:mode]&.to_i
 
-			if mode == Entry::MODE_PATTERN
+			if mode == EntryMode::PATTERN
 				dictionary.empty_patterns
 			else
 				dictionary.empty_entries(mode)

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -39,7 +39,7 @@ class EntriesController < ApplicationController
 			entry = dictionary.entries.where(label:label, identifier:identifier).first
 			raise ArgumentError, "The entry #{entry} already exists in the dictionary." unless entry.nil?
 
-			entry = dictionary.new_entry(label, identifier, nil, Entry::MODE_WHITE, true)
+			entry = dictionary.new_entry(label, identifier, nil, EntryMode::WHITE, true)
 
 			tag_ids = params[:tags] || []
 			entry.tag_ids = tag_ids

--- a/app/helpers/dictionaries_helper.rb
+++ b/app/helpers/dictionaries_helper.rb
@@ -51,7 +51,7 @@ module DictionariesHelper
 	end
 
 	def delete_entries_helper(mode = nil)
-		mode_to_s = Entry.mode_to_s(mode)
+		mode_to_s = EntryMode.to_s(mode)
 
 		title = if mode == EntryMode::BLACK
 			"Turn all the black entries to gray"

--- a/app/helpers/dictionaries_helper.rb
+++ b/app/helpers/dictionaries_helper.rb
@@ -40,7 +40,7 @@ module DictionariesHelper
 				link_to(content_tag(:i, '', class:"fa fa-download"), downloadable_dictionary_path(@dictionary), title: "Download")
 			end
 		else
-			link_to(content_tag(:i, '', class:"fa fa-download"), params.permit(:mode).merge(mode: Entry::MODE_ACTIVE, format: :tsv), title: "Download")
+			link_to(content_tag(:i, '', class:"fa fa-download"), params.permit(:mode).merge(mode: EntryMode::ACTIVE, format: :tsv), title: "Download")
 		end
 	end
 
@@ -53,13 +53,13 @@ module DictionariesHelper
 	def delete_entries_helper(mode = nil)
 		mode_to_s = Entry.mode_to_s(mode)
 
-		title = if mode == Entry::MODE_BLACK
+		title = if mode == EntryMode::BLACK
 			"Turn all the black entries to gray"
 		else
 			"Delete all the #{mode_to_s} entries"
 		end
 
-		confirm = if mode == Entry::MODE_BLACK
+		confirm = if mode == EntryMode::BLACK
 			"Are you sure to turn all the black entries to gray?"
 		else
 			"Are you sure to delete all the #{mode_to_s} entries?"

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -23,7 +23,7 @@ class LoadEntriesFromFileJob < ApplicationJob
 
     def add_entry(label, identifier, mode)
       case mode
-      when Entry::MODE_PATTERN
+      when EntryMode::PATTERN
         buffer_pattern(label, identifier)
       else
         buffer_entry(label, identifier, mode)
@@ -46,11 +46,11 @@ class LoadEntriesFromFileJob < ApplicationJob
       matched = entries_any? && @dictionary.entries.where(label:label, identifier:identifier)&.first
       if matched
         case mode
-        when Entry::MODE_GRAY
+        when EntryMode::GRAY
           @num_skipped_entries += 1
-        when Entry::MODE_WHITE
+        when EntryMode::WHITE
           matched.be_white!
-        when Entry::MODE_BLACK
+        when EntryMode::BLACK
           matched.be_black!
         else
           raise ArgumentError, "Unexpected mode: #{mode}"

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -85,9 +85,9 @@ class Entry < ApplicationRecord
       tsv << ['#label', :id, :operator]
       all.each do |entry|
         operator = case entry.mode
-        when MODE_WHITE
+        when EntryMode::WHITE
           '+'
-        when MODE_BLACK
+        when EntryMode::BLACK
           '-'
         end
         tsv << [entry.label, entry.identifier, operator]

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -71,10 +71,6 @@ class Entry < ApplicationRecord
     }
   end
 
-  def self.mode_to_s(mode)
-    EntryMode.to_s(mode)
-  end
-
   def self.as_tsv
     CSV.generate(col_sep: "\t") do |tsv|
       tsv << ['#label', :id]

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,12 +1,4 @@
 class Entry < ApplicationRecord
-  MODE_GRAY  = 0
-  MODE_WHITE = 1
-  MODE_BLACK = 2
-  MODE_ACTIVE = 3 # gray + white (for downloading)
-  MODE_CUSTOM = 4 # white + black (for downloading)
-  MODE_PATTERN = 5 # patterns (regular expressions)
-  MODE_AUTO_EXPANDED = 6
-
   include Elasticsearch::Model
 
   settings index: {
@@ -56,12 +48,12 @@ class Entry < ApplicationRecord
   validates :identifier, presence: true
   validates :score, numericality: { greater_than_or_equal_to: 0, less_than: 1 }, allow_nil: true
 
-  scope :gray, -> {where(mode: Entry::MODE_GRAY)}
-  scope :white, -> {where(mode: Entry::MODE_WHITE)}
-  scope :black, -> {where(mode: Entry::MODE_BLACK)}
-  scope :custom, -> {where(mode: [Entry::MODE_WHITE, Entry::MODE_BLACK])}
-  scope :active, -> {where(mode: [Entry::MODE_GRAY, Entry::MODE_WHITE])}
-  scope :auto_expanded, -> {where(mode: Entry::MODE_AUTO_EXPANDED).order(score: :desc)}
+  scope :gray, -> {where(mode: EntryMode::GRAY)}
+  scope :white, -> {where(mode: EntryMode::WHITE)}
+  scope :black, -> {where(mode: EntryMode::BLACK)}
+  scope :custom, -> {where(mode: [EntryMode::WHITE, EntryMode::BLACK])}
+  scope :active, -> {where(mode: [EntryMode::GRAY, EntryMode::WHITE])}
+  scope :auto_expanded, -> {where(mode: EntryMode::AUTO_EXPANDED).order(score: :desc)}
 
   scope :simple_paginate, -> (page = 1, per = 15) {
     offset = (page - 1) * per
@@ -122,13 +114,13 @@ class Entry < ApplicationRecord
 
     mode = case items[2]
     when '+'
-      Entry::MODE_WHITE
+      EntryMode::WHITE
     when '-'
-      Entry::MODE_BLACK
+      EntryMode::BLACK
     when '/'
-      Entry::MODE_PATTERN
+      EntryMode::PATTERN
     else
-      Entry::MODE_GRAY
+      EntryMode::GRAY
     end
 
     [items[0], items[1], mode]
@@ -139,23 +131,23 @@ class Entry < ApplicationRecord
   end
 
   def be_gray!
-    update_attribute(:mode, Entry::MODE_GRAY)
+    update_attribute(:mode, EntryMode::GRAY)
   end
 
   def be_white!
-    update_attribute(:mode, Entry::MODE_WHITE)
+    update_attribute(:mode, EntryMode::WHITE)
   end
 
   def be_black!
-    update_attribute(:mode, Entry::MODE_BLACK)
+    update_attribute(:mode, EntryMode::BLACK)
   end
 
   def is_white?
-    mode == Entry::MODE_WHITE
+    mode == EntryMode::WHITE
   end
 
   def is_black?
-    mode == Entry::MODE_BLACK
+    mode == EntryMode::BLACK
   end
 
   def self.normalize(text, normalizer, analyzer = nil)

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -80,7 +80,7 @@ class Entry < ApplicationRecord
   end
 
   def self.mode_to_s(mode)
-    mode.nil? ? '' : ['gray', 'white', 'black', 'active', 'custom', 'pattern', 'auto expanded'][mode]
+    EntryMode.to_s(mode)
   end
 
   def self.as_tsv

--- a/app/models/entry_mode.rb
+++ b/app/models/entry_mode.rb
@@ -1,20 +1,20 @@
 class EntryMode
-  MODE_GRAY  = 0
-  MODE_WHITE = 1
-  MODE_BLACK = 2
-  MODE_ACTIVE = 3 # gray + white (for downloading)
-  MODE_CUSTOM = 4 # white + black (for downloading)
-  MODE_PATTERN = 5 # patterns (regular expressions)
-  MODE_AUTO_EXPANDED = 6
+  GRAY  = 0
+  WHITE = 1
+  BLACK = 2
+  ACTIVE = 3 # gray + white (for downloading)
+  CUSTOM = 4 # white + black (for downloading)
+  PATTERN = 5 # patterns (regular expressions)
+  AUTO_EXPANDED = 6
 
   MODES = {
-    MODE_GRAY  => 'gray',
-    MODE_WHITE => 'white',
-    MODE_BLACK => 'black',
-    MODE_ACTIVE => 'active',
-    MODE_CUSTOM => 'custom',
-    MODE_PATTERN => 'pattern',
-    MODE_AUTO_EXPANDED => 'auto expand'
+    GRAY  => 'gray',
+    WHITE => 'white',
+    BLACK => 'black',
+    ACTIVE => 'active',
+    CUSTOM => 'custom',
+    PATTERN => 'pattern',
+    AUTO_EXPANDED => 'auto expand'
   }.freeze
 
   def self.to_s(mode)

--- a/app/models/entry_mode.rb
+++ b/app/models/entry_mode.rb
@@ -1,0 +1,24 @@
+class EntryMode
+  MODE_GRAY  = 0
+  MODE_WHITE = 1
+  MODE_BLACK = 2
+  MODE_ACTIVE = 3 # gray + white (for downloading)
+  MODE_CUSTOM = 4 # white + black (for downloading)
+  MODE_PATTERN = 5 # patterns (regular expressions)
+  MODE_AUTO_EXPANDED = 6
+
+  MODES = {
+    MODE_GRAY  => 'gray',
+    MODE_WHITE => 'white',
+    MODE_BLACK => 'black',
+    MODE_ACTIVE => 'active',
+    MODE_CUSTOM => 'custom',
+    MODE_PATTERN => 'pattern',
+    MODE_AUTO_EXPANDED => 'auto expand'
+  }.freeze
+
+  def self.to_s(mode)
+    MODES[mode] || ''
+  end
+
+end

--- a/app/views/dictionaries/_counts.erb
+++ b/app/views/dictionaries/_counts.erb
@@ -9,29 +9,29 @@
       </colgroup>
       <tr>
         <th colspan="2" class="active" style="border-style:none" title="<%= t('title.active') %>">
-          <%= link_to 'Active', params.permit(:mode).merge(mode: Entry::MODE_ACTIVE) %>
+          <%= link_to 'Active', params.permit(:mode).merge(mode: EntryMode::ACTIVE) %>
           <%= downloadable_helper %>
         </th>
       </tr>
       <tr>
         <td style="border-style:none"></td>
         <th colspan="2" class="custom" style="border-style:none" title="<%= t('title.custom') %>">
-          <%= link_to 'Custom', params.permit(:mode).merge(mode: Entry::MODE_CUSTOM) %>
-          <%= link_to(content_tag(:i, '', class:"fa fa-download"), params.permit(:mode).merge(mode: Entry::MODE_CUSTOM, format: :tsv), title: "Download") %>
+          <%= link_to 'Custom', params.permit(:mode).merge(mode: EntryMode::CUSTOM) %>
+          <%= link_to(content_tag(:i, '', class:"fa fa-download"), params.permit(:mode).merge(mode: EntryMode::CUSTOM, format: :tsv), title: "Download") %>
         </th>
       </tr>
       <tr>
         <th class="gray" title="<%= t('title.gray') %>">
-          <%= link_to_unless_current '# Gray', params.permit(:mode).except(:mode).merge(mode: Entry::MODE_GRAY) %>
+          <%= link_to_unless_current '# Gray', params.permit(:mode).except(:mode).merge(mode: EntryMode::GRAY) %>
         </th>
         <th class="white" title="<%= t('title.white') %>">
-          <%= link_to_unless_current '# White', params.permit(:mode).merge(mode: Entry::MODE_WHITE) %>
+          <%= link_to_unless_current '# White', params.permit(:mode).merge(mode: EntryMode::WHITE) %>
         </th>
         <th class="black" title="<%= t('title.black') %>">
-          <%= link_to_unless_current '# Black', params.permit(:mode).merge(mode: Entry::MODE_BLACK) %>
+          <%= link_to_unless_current '# Black', params.permit(:mode).merge(mode: EntryMode::BLACK) %>
         </th>
         <th class="auto_expanded" title="<%= t('title.auto_expanded') %>">
-          <%= link_to_unless_current '# Auto expanded', params.permit(:mode).merge(mode: Entry::MODE_AUTO_EXPANDED) %>
+          <%= link_to_unless_current '# Auto expanded', params.permit(:mode).merge(mode: EntryMode::AUTO_EXPANDED) %>
         </th>
       </tr>
       <tr>
@@ -41,10 +41,10 @@
         <td style="text-align: right"><%= @dictionary.num_auto_expanded %></td>
       </tr>
       <tr>
-        <th><%= delete_entries_helper(Entry::MODE_GRAY) %></th>
-        <th><%= delete_entries_helper(Entry::MODE_WHITE) %></th>
-        <th><%= delete_entries_helper(Entry::MODE_BLACK) %></th>
-        <th><%= delete_entries_helper(Entry::MODE_AUTO_EXPANDED) %></th>
+        <th><%= delete_entries_helper(EntryMode::GRAY) %></th>
+        <th><%= delete_entries_helper(EntryMode::WHITE) %></th>
+        <th><%= delete_entries_helper(EntryMode::BLACK) %></th>
+        <th><%= delete_entries_helper(EntryMode::AUTO_EXPANDED) %></th>
       </tr>
     </table>
   <% else %>

--- a/app/views/dictionaries/show_patterns.html.erb
+++ b/app/views/dictionaries/show_patterns.html.erb
@@ -8,7 +8,7 @@
 		<%=
 			link_to(
 				content_tag(:i, '', class:"fa-regular fa-trash-can fa-lg"),
-				empty_dictionary_patterns_path(@dictionary, mode:Entry::MODE_PATTERN),
+				empty_dictionary_patterns_path(@dictionary, mode:EntryMode::PATTERN),
 				title: 'Delete all the patterns',
 				method: :put,
 				data: {confirm: 'Are you sure to delete all the patterns?'}

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -1,10 +1,10 @@
 <%
   tr_class = if @dictionary.editable?(current_user)
     case entry.mode
-      when Entry::MODE_GRAY then "entry gray"
-      when Entry::MODE_WHITE then "entry white"
-      when Entry::MODE_BLACK then "entry black"
-      when Entry::MODE_AUTO_EXPANDED then "entry auto expanded"
+      when EntryMode::GRAY then "entry gray"
+      when EntryMode::WHITE then "entry white"
+      when EntryMode::BLACK then "entry black"
+      when EntryMode::AUTO_EXPANDED then "entry auto expanded"
       else "entry"
     end
   else
@@ -34,7 +34,7 @@
     <% end %>
   </td>
   <td style="border-left-style: none"></td>
-  <% if entry.mode == Entry::MODE_AUTO_EXPANDED %>
+  <% if entry.mode == EntryMode::AUTO_EXPANDED %>
     <td style="border-right-style: none">
       <%= entry.score %>
     </td>
@@ -42,13 +42,13 @@
   <% if @dictionary.editable?(current_user) %>
     <td style="text-align:center">
       <% case entry.mode %>
-      <% when Entry::MODE_GRAY %>
+      <% when EntryMode::GRAY %>
         <input type="checkbox" name="entry_id[]" id="entry_id_<%= entry.id %>" class="chkbox" value="<%= entry.id %>">
-      <% when Entry::MODE_WHITE %>
+      <% when EntryMode::WHITE %>
         <%= link_to('<i class="fa-regular fa-trash-can" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Remove') %>
-      <% when Entry::MODE_BLACK %>
+      <% when EntryMode::BLACK %>
         <%= link_to('<i class="fa fa-undo" aria-hidden="true"></i>'.html_safe, undo_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Back to gray') %>
-      <% when Entry::MODE_AUTO_EXPANDED %>
+      <% when EntryMode::AUTO_EXPANDED %>
         <input type="checkbox" name="entry_id[]" id="entry_id_<%= entry.id %>" class="chkbox" value="<%= entry.id %>">
       <% else %>
       <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,18 +18,18 @@ end
 
 # create entries for each mode
 entry_items = [
-  { mode: Entry::MODE_GRAY, label: "Gray Mode Entry", identifier: "1", tags: seed_tags },
-  { mode: Entry::MODE_GRAY, label: "Gray Mode Entry2", identifier: "2", tags: [seed_tags.first, seed_tags.third] },
-  { mode: Entry::MODE_WHITE, label: "White Mode Entry", identifier: "1", tags: seed_tags },
-  { mode: Entry::MODE_WHITE, label: "White Mode Entry2", identifier: "2", tags: [seed_tags.third] },
-  { mode: Entry::MODE_WHITE, label: "White Mode Entry3", identifier: "2", tags: [] },
-  { mode: Entry::MODE_WHITE, label: "White Mode Entry4", identifier: "3", tags: [seed_tags.first, seed_tags.third] },
-  { mode: Entry::MODE_WHITE, label: "White Mode Entry5", identifier: "4", tags: [] },
-  { mode: Entry::MODE_BLACK, label: "Black Mode Entry", identifier: "3", tags: [seed_tags.second, seed_tags.third] },
-  { mode: Entry::MODE_BLACK, label: "Black Mode Entry2", identifier: "1", tags: [] },
-  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry", identifier: "1", tags: [seed_tags.second], score: 0.5 },
-  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry2", identifier: "1", tags: [], score: 0.9999 },
-  { mode: Entry::MODE_AUTO_EXPANDED, label: "Auto Expanded Mode Entry3", identifier: "3", tags: seed_tags, score: 0 },
+  { mode: EntryMode::GRAY, label: "Gray Mode Entry", identifier: "1", tags: seed_tags },
+  { mode: EntryMode::GRAY, label: "Gray Mode Entry2", identifier: "2", tags: [seed_tags.first, seed_tags.third] },
+  { mode: EntryMode::WHITE, label: "White Mode Entry", identifier: "1", tags: seed_tags },
+  { mode: EntryMode::WHITE, label: "White Mode Entry2", identifier: "2", tags: [seed_tags.third] },
+  { mode: EntryMode::WHITE, label: "White Mode Entry3", identifier: "2", tags: [] },
+  { mode: EntryMode::WHITE, label: "White Mode Entry4", identifier: "3", tags: [seed_tags.first, seed_tags.third] },
+  { mode: EntryMode::WHITE, label: "White Mode Entry5", identifier: "4", tags: [] },
+  { mode: EntryMode::BLACK, label: "Black Mode Entry", identifier: "3", tags: [seed_tags.second, seed_tags.third] },
+  { mode: EntryMode::BLACK, label: "Black Mode Entry2", identifier: "1", tags: [] },
+  { mode: EntryMode::AUTO_EXPANDED, label: "Auto Expanded Mode Entry", identifier: "1", tags: [seed_tags.second], score: 0.5 },
+  { mode: EntryMode::AUTO_EXPANDED, label: "Auto Expanded Mode Entry2", identifier: "1", tags: [], score: 0.9999 },
+  { mode: EntryMode::AUTO_EXPANDED, label: "Auto Expanded Mode Entry3", identifier: "3", tags: seed_tags, score: 0 },
 ]
 
 entry_items.each do |entry_def|


### PR DESCRIPTION
#83 
EntryModeクラス作成が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- EntryModeモデルを作成し、Entryモデルで定義していたentry.modeの定数定義などを移動させた
- 上記変更に伴い、定数名を変更し、使用している箇所も修正
- `entry.mode_to_s`で文字列に変換するメソッドについて、EntryModeモデルで実施するように変更(前PRでコメントいただいていた箇所)
- 動作確認し、変更前と同じ挙動になることを確認

## 実施していないこと
- Mode情報を使用しているEntryモデル内のメソッドは他にもありますが、一旦定数名を変更するだけの対応とし、EntryModeモデルへ移管したりはしていません。その必要があるものがあれば、追加で対応します。

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/fb01d82b-5d3b-494e-a6e0-c9e1e97ba80f

