### PR TITLE
Dictionary#expand_synonymメソッドを実装

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -515,6 +515,31 @@ class Dictionary < ApplicationRecord
     true
   end
 
+  def expand_synonym
+    identifiers = entries.pluck(:identifier).uniq
+
+    identifiers.each do |identifier|
+      synonyms = entries.where(identifier: identifier).pluck(:label)
+      expanded_synonyms = synonym_expansion(synonyms)
+
+      expanded_synonyms.each do |expanded_synonym|
+        transaction do
+          entries.create!(
+            label: expanded_synonym[:label],
+            identifier: identifier,
+            score: expanded_synonym[:score],
+            mode: EntryMode::AUTO_EXPANDED
+          )
+          update_entries_num
+        end
+      end
+    end
+  end
+
+  def synonym_expansion(synonyms)
+    # setting dummy method for next issue
+  end
+
 	private
 
 	def ngram_order

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -522,16 +522,16 @@ class Dictionary < ApplicationRecord
       synonyms = entries.where(identifier: identifier).pluck(:label)
       expanded_synonyms = synonym_expansion(synonyms)
 
-      expanded_synonyms.each do |expanded_synonym|
-        transaction do
+      transaction do
+        expanded_synonyms.each do |expanded_synonym|
           entries.create!(
             label: expanded_synonym[:label],
             identifier: identifier,
             score: expanded_synonym[:score],
             mode: EntryMode::AUTO_EXPANDED
           )
-          update_entries_num
         end
+        update_entries_num
       end
     end
   end


### PR DESCRIPTION
close #80 
Dictionary#expand_synonymメソッドの実装が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- issue記載の仕様通りに動作するよう、`expand_synonym`メソッドを作成
- `synonym_expansion`メソッドの返り値は、`label`と`score`を含むハッシュ配列と仮定して実装

## 実施していないこと
- 動作確認は次issueで実施の認識です
- 例外処理などはまだ考慮できていません
- `synonym_expansion`メソッドは中身未実装