### PR TITLE
synonym_expansionメソッドのダミー実装

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -537,7 +537,13 @@ class Dictionary < ApplicationRecord
   end
 
   def synonym_expansion(synonyms)
-    # setting dummy method for next issue
+    expanded_synonyms = []
+    synonyms.each_with_index do |label, i|
+      expanded_label = "#{label}--dummy-synonym-#{i + 1}"
+      score = rand.round(4)
+      expanded_synonyms << { label: expanded_label, score: score }
+    end
+    expanded_synonyms
   end
 
 	private

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -537,13 +537,11 @@ class Dictionary < ApplicationRecord
   end
 
   def synonym_expansion(synonyms)
-    expanded_synonyms = []
-    synonyms.each_with_index do |label, i|
+    synonyms.map.with_index do |label, i|
       expanded_label = "#{label}--dummy-synonym-#{i + 1}"
       score = rand.round(4)
-      expanded_synonyms << { label: expanded_label, score: score }
+      { label: expanded_label, score:  }
     end
-    expanded_synonyms
   end
 
 	private

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -519,7 +519,7 @@ class Dictionary < ApplicationRecord
     identifiers = entries.pluck(:identifier).uniq
 
     identifiers.each do |identifier|
-      synonyms = entries.where(identifier: identifier).pluck(:label)
+      synonyms = entries.where(identifier: identifier).where.not(mode: EntryMode::BLACK).pluck(:label)
       expanded_synonyms = synonym_expansion(synonyms)
 
       transaction do

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -34,7 +34,7 @@
     <% end %>
   </td>
   <td style="border-left-style: none"></td>
-  <% if entry.mode == EntryMode::AUTO_EXPANDED %>
+  <% if @type_entries == 'Auto expanded' %>
     <td style="border-right-style: none">
       <%= entry.score %>
     </td>


### PR DESCRIPTION
close #81 
synonym_expansionメソッドのダミー実装が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 前issueの`expand_synonym`メソッドにおいて、Blackモードのentryは除外するように追加実装
- `synonym_expansion`メソッドをダミーで実装(issueの通り)
- 一回手動で関数実行してみて、問題なく動作することを確認

## 実行結果
- Auto expandedに関数実行後のentryが格納されている
- IDで絞り込みをしたとき、Black以外のモードのentryがダミーlabelで複製(拡張)されて保存されている

https://github.com/pubannotation/pubdictionaries/assets/149556430/11aead36-645d-4b20-ab70-9c87a53b1d88

