### PR TITLE
ExpandSynonymJobの実装

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -366,7 +366,6 @@ class DictionariesController < ApplicationController
 		rescue => e
 			respond_to do |format|
 				format.html {redirect_to dictionary_path(dictionary), notice: e.message}
-				format.json {head :no_content}
 			end
 		end
 	end

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -352,24 +352,6 @@ class DictionariesController < ApplicationController
 		end
 	end
 
-	def expand_synonym
-		begin
-			dictionary = Dictionary.editable(current_user).find_by_name(params[:id])
-			raise ArgumentError, "Cannot find the dictionary" if dictionary.nil?
-
-			active_job = ExpandSynonymJob.perform_later(dictionary)
-			active_job.create_job_record("Automatically expand synonyms for entries")
-
-			respond_to do |format|
-				format.html{ redirect_back fallback_location: root_path }
-			end
-		rescue => e
-			respond_to do |format|
-				format.html {redirect_to dictionary_path(dictionary), notice: e.message}
-			end
-		end
-	end
-
 	def destroy
 		begin
 			dictionary = Dictionary.administrable(current_user).find_by_name(params[:id])

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -352,6 +352,25 @@ class DictionariesController < ApplicationController
 		end
 	end
 
+	def expand_synonym
+		begin
+			dictionary = Dictionary.editable(current_user).find_by_name(params[:id])
+			raise ArgumentError, "Cannot find the dictionary" if dictionary.nil?
+
+			active_job = ExpandSynonymJob.perform_later(dictionary)
+			active_job.create_job_record("Automatically expand synonyms for entries")
+
+			respond_to do |format|
+				format.html{ redirect_back fallback_location: root_path }
+			end
+		rescue => e
+			respond_to do |format|
+				format.html {redirect_to dictionary_path(dictionary), notice: e.message}
+				format.json {head :no_content}
+			end
+		end
+	end
+
 	def destroy
 		begin
 			dictionary = Dictionary.administrable(current_user).find_by_name(params[:id])

--- a/app/controllers/expand_synonym_jobs_controller.rb
+++ b/app/controllers/expand_synonym_jobs_controller.rb
@@ -8,11 +8,11 @@ class ExpandSynonymJobsController < ApplicationController
       active_job.create_job_record("Automatically expand synonyms for entries")
 
       respond_to do |format|
-      format.html{ redirect_back fallback_location: root_path }
+        format.html{ redirect_back fallback_location: root_path }
       end
     rescue => e
       respond_to do |format|
-      format.html {redirect_to dictionary_path(dictionary), notice: e.message}
+        format.html {redirect_to dictionary_path(dictionary), notice: e.message}
       end
     end
   end

--- a/app/controllers/expand_synonym_jobs_controller.rb
+++ b/app/controllers/expand_synonym_jobs_controller.rb
@@ -1,0 +1,19 @@
+class ExpandSynonymJobsController < ApplicationController
+  def create
+    begin
+      dictionary = Dictionary.editable(current_user).find_by_name(params[:id])
+      raise ArgumentError, "Cannot find the dictionary" if dictionary.nil?
+
+      active_job = ExpandSynonymJob.perform_later(dictionary)
+      active_job.create_job_record("Automatically expand synonyms for entries")
+
+      respond_to do |format|
+      format.html{ redirect_back fallback_location: root_path }
+      end
+    rescue => e
+      respond_to do |format|
+      format.html {redirect_to dictionary_path(dictionary), notice: e.message}
+      end
+    end
+  end
+end

--- a/app/jobs/expand_synonym_job.rb
+++ b/app/jobs/expand_synonym_job.rb
@@ -2,7 +2,7 @@ class ExpandSynonymJob < ApplicationJob
   queue_as :general
 
   def perform(dictionary)
-    dictionary.expand_synonym!
+    dictionary.expand_synonym
   end
 
   before_perform do |active_job|

--- a/app/jobs/expand_synonym_job.rb
+++ b/app/jobs/expand_synonym_job.rb
@@ -1,0 +1,16 @@
+class ExpandSynonymJob < ApplicationJob
+  queue_as :general
+
+  def perform(dictionary)
+    dictionary.expand_synonym!
+  end
+
+  before_perform do |active_job|
+    set_job(active_job)
+    set_begun_at
+  end
+
+  after_perform do
+    set_ended_at
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,11 +50,11 @@ Rails.application.routes.draw do
       get  'substring_completion', to: 'lookup#substring_completion'
       get  'mixed_completion', to: 'lookup#mixed_completion'
       get 'compile'
-      post 'expand_synonym'
       get 'downloadable'
       post 'downloadable', to: 'dictionaries#create_downloadable', as: 'create_downloadable'
       post 'managers', to: 'dictionaries#add_manager'
       delete 'managers/:username', to: 'dictionaries#remove_manager', as: 'manager'
+      resources :expand_synonym_jobs, only: :create
     end
 
     resources :entries do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
       get  'substring_completion', to: 'lookup#substring_completion'
       get  'mixed_completion', to: 'lookup#mixed_completion'
       get 'compile'
+      post 'expand_synonym'
       get 'downloadable'
       post 'downloadable', to: 'dictionaries#create_downloadable', as: 'create_downloadable'
       post 'managers', to: 'dictionaries#add_manager'


### PR DESCRIPTION
close #82 
ExpandSynonymJobの実装が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- ExpandSynonymJobを作成し、`expand_synonym`を実行するように設定
- `DitionaryController#expand_synonym`を作成し、`compile`を参考にJobを実行するよう実装
- `DitionaryController#expand_synonym`をルーティング(compileはGETでしたが、entryの作成が含まれるためPOSTにしました)

## 実施していないこと
- このアクションをトリガーするボタンの作成などは次issueで実施