### PR TITLE
dictionary編集にexpand_synonym機能追加

### DIFF
--- a/app/views/dictionaries/_expand_synonym.html.erb
+++ b/app/views/dictionaries/_expand_synonym.html.erb
@@ -1,0 +1,9 @@
+<fieldset class="dialog">
+  <legend>Automatically expand synonyms</legend>
+
+  <p class="note">You can automatically expand synonyms for entries.</p>
+
+  <%= form_with url: expand_synonym_jobs_path(@dictionary), method: :post do |f| %>
+    <%= f.submit 'Expand Synonym', class: 'button' %>
+  <% end %>
+</fieldset>

--- a/app/views/dictionaries/edit.html.erb
+++ b/app/views/dictionaries/edit.html.erb
@@ -40,6 +40,7 @@
 	<%= render partial: 'commands' -%>
 	<%= render partial: 'upload' -%>
 	<%= render partial: 'compile' -%>
+	<%= render partial: 'expand_synonym' -%>
 <% else %>
 	<%= render partial: 'last_task' -%>
 <% end %>


### PR DESCRIPTION
close #85 
dictionary編集へのexpand_synonym機能追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Dictionary編集画面の一番下にexpand_synonymの実行ボタンを追加し、ボタン押下で`ExpandSynonymJobsController#create`が実行されるようにする
- 手動で実行できていることを確認

## 特記事項
各種文言は指示になかったので、校正していただけますと幸いです。

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/0925a019-7c82-4ccf-89e6-f41ddd7b9be8

