### PR TITLE
auto_expandのentryをwhiteに確定する機能の追加

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -135,6 +135,30 @@ class EntriesController < ApplicationController
 		end
 	end
 
+	def confirm_to_white
+		begin
+			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
+			raise ArgumentError, "Cannot find the dictionary" if dictionary.nil?
+
+			entry = Entry.find(params[:id])
+			raise ArgumentError, "Cannot find the entry" if entry.nil?
+
+			dictionary.confirm_entry(entry)
+		rescue => e
+			message = e.message
+		end
+
+		respond_to do |format|
+			format.html{
+				if dictionary.entries.white.exists? || dictionary.entries.auto_expanded.exists?
+					redirect_back fallback_location: root_path, notice: message
+				else
+					redirect_to dictionary
+				end
+			}
+		end
+	end
+
 	def destroy_entries
 		begin
 			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -144,18 +144,24 @@ class EntriesController < ApplicationController
 			raise ArgumentError, "Cannot find the entry" if entry.nil?
 
 			dictionary.confirm_entry(entry)
-		rescue => e
-			message = e.message
-		end
 
-		respond_to do |format|
-			format.html{
-				if dictionary.entries.auto_expanded.exists?
-					redirect_back fallback_location: root_path, notice: message
-				else
-					redirect_to dictionary
-				end
-			}
+			respond_to do |format|
+				format.html{
+					if dictionary.entries.auto_expanded.exists?
+						redirect_back fallback_location: root_path
+					else
+						redirect_to dictionary
+					end
+				}
+			end
+		rescue ArgumentError => e
+			respond_to do |format|
+				format.html {flash.now[:notice] = e.message}
+			end
+		rescue => e
+			respond_to do |format|
+				format.html { redirect_to dictionary, notice: e.message }
+			end
 		end
 	end
 

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -136,32 +136,30 @@ class EntriesController < ApplicationController
 	end
 
 	def confirm_to_white
-		begin
-			dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
-			raise ArgumentError, "Cannot find the dictionary" if dictionary.nil?
+		dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
+		raise ArgumentError, "Cannot find the dictionary" if dictionary.nil?
 
-			entry = Entry.find(params[:id])
-			raise ArgumentError, "Cannot find the entry" if entry.nil?
+		entry = Entry.find(params[:id])
+		raise ArgumentError, "Cannot find the entry" if entry.nil?
 
-			dictionary.confirm_entry(entry)
+		dictionary.confirm_entry(entry)
 
-			respond_to do |format|
-				format.html{
-					if dictionary.entries.auto_expanded.exists?
-						redirect_back fallback_location: root_path
-					else
-						redirect_to dictionary
-					end
-				}
-			end
-		rescue ArgumentError => e
-			respond_to do |format|
-				format.html {flash.now[:notice] = e.message}
-			end
-		rescue => e
-			respond_to do |format|
-				format.html { redirect_to dictionary, notice: e.message }
-			end
+		respond_to do |format|
+			format.html{
+				if dictionary.entries.auto_expanded.exists?
+					redirect_back fallback_location: root_path
+				else
+					redirect_to dictionary
+				end
+			}
+		end
+	rescue ArgumentError => e
+		respond_to do |format|
+			format.html {flash.now[:notice] = e.message}
+		end
+	rescue => e
+		respond_to do |format|
+			format.html { redirect_to dictionary, notice: e.message }
 		end
 	end
 

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -150,7 +150,7 @@ class EntriesController < ApplicationController
 
 		respond_to do |format|
 			format.html{
-				if dictionary.entries.white.exists? || dictionary.entries.auto_expanded.exists?
+				if dictionary.entries.auto_expanded.exists?
 					redirect_back fallback_location: root_path, notice: message
 				else
 					redirect_to dictionary

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -165,6 +165,13 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
+	def confirm_entry(entry)
+		transaction do
+			entry.be_white!
+			update_entries_num
+		end
+	end
+
   def update_entries_num
 		non_black_num = entries.where.not(mode: EntryMode::BLACK).count
 		update(entries_num: non_black_num)

--- a/app/views/entries/_colgroup.erb
+++ b/app/views/entries/_colgroup.erb
@@ -6,6 +6,7 @@
     <col class="col_button">
     <% if type_entries == 'Auto expanded' %>
       <col class="col_score">
+      <col class="col_button">
     <% end %>
     <% if dictionary.editable?(current_user) %>
       <col class="col_button">

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -39,7 +39,7 @@
       <%= entry.score %>
     </td>
     <td style="border-right-style: none; text-align: center">
-      <%= link_to('<i class="fa-regular fa-circle-check"></i>'.html_safe, '#_path(@dictionary, entry)', method: :put, title: 'Auto expanded to white') %>
+      <%= link_to('<i class="fa-regular fa-circle-check"></i>'.html_safe, confirm_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Auto expanded to white') %>
     </td>
   <% end %>
   <% if @dictionary.editable?(current_user) %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -38,9 +38,12 @@
     <td style="border-right-style: none">
       <%= entry.score %>
     </td>
+    <td style="border-right-style: none; text-align: center">
+      <%= link_to('<i class="fa-regular fa-circle-check"></i>'.html_safe, '#_path(@dictionary, entry)', method: :put, title: 'Auto expanded to white') %>
+    </td>
   <% end %>
   <% if @dictionary.editable?(current_user) %>
-    <td style="text-align:center">
+    <td style="text-align: center">
       <% case entry.mode %>
       <% when EntryMode::GRAY %>
         <input type="checkbox" name="entry_id[]" id="entry_id_<%= entry.id %>" class="chkbox" value="<%= entry.id %>">

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -35,6 +35,7 @@
     <col class="col_button">
     <% if @type_entries == 'Auto expanded' %>
       <col class="col_score">
+      <col class="col_button">
     <% end %>
     <% if @dictionary.editable?(current_user) %>
       <col class="col_button">
@@ -71,9 +72,10 @@
       </th>
       <% if @type_entries == 'Auto expanded' %>
         <th>Score</th>
+        <th style="border-right-style: none"></th>
       <% end %>
       <% if @dictionary.editable?(current_user) %>
-        <th></th>
+        <th style="border-left-style: none"></th>
       <% end %>
     </tr>
   </thead>
@@ -97,6 +99,7 @@
             <a title="switch selected entries to black" href="javascript:{}" onclick="document.getElementById('switch_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>
           </td>
         <% elsif ['Auto expanded'].include?(@type_entries) %>
+          <td style="border-style:none"></td>
           <td style="border-style:none"></td>
           <td style="text-align:center">
             <a title="remove selected entries" href="javascript:{}" onclick="if(confirm('Are you sure to remove selected entries?')) { document.getElementById('delete_entries_form').submit(); } return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
@@ -142,6 +145,7 @@
     <col class="col_tags">
     <% if @type_entries == 'Auto expanded' %>
       <col class="col_score">
+      <col class="col_button">
     <% end %>
     <col class="col_button">
   </colgroup>
@@ -158,7 +162,7 @@
           <span><%= select_tag :tags, options_from_collection_for_select(Tag.where(dictionary_id: @dictionary.id), 'id', 'value'), multiple: true, class: 'js-searchable', style: "box-sizing:content-box; width:100%"  %></span>
         </td>
         <% if @type_entries == 'Auto expanded' %>
-          <td></td>
+          <td style="border-right-style: none"></td><td style="border-left-style: none"></td>
         <% end %>
         <td style="text-align:center">
           <a title="add" href="javascript:{}" onclick="document.getElementById('add_entry_form').submit(); return false;"><i class="fa fa-plus-square" aria-hidden="true"></i></a>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -162,7 +162,7 @@
           <span><%= select_tag :tags, options_from_collection_for_select(Tag.where(dictionary_id: @dictionary.id), 'id', 'value'), multiple: true, class: 'js-searchable', style: "box-sizing:content-box; width:100%"  %></span>
         </td>
         <% if @type_entries == 'Auto expanded' %>
-          <td style="border-right-style: none"></td><td style="border-left-style: none"></td>
+          <td colspan="2"></td>
         <% end %>
         <td style="text-align:center">
           <a title="add" href="javascript:{}" onclick="document.getElementById('add_entry_form').submit(); return false;"><i class="fa fa-plus-square" aria-hidden="true"></i></a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
 
       member do
         put 'undo', to: "entries#undo"
+        put 'confirm', to: "entries#confirm_to_white"
       end
     end
 


### PR DESCRIPTION
close #84 
auto_expandのentryをwhiteに確定する機能の追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Dictionary詳細画面のAuto expanded絞り込み画面において、Scoreの右列にWhiteモードへの確定ボタンを設置
- ボタンを押したら、そのentryはWhiteモードに切り替わるように設定
- 切り替わりに伴い、右上のカウンターが変動し、切り替えたentryはWhiteの画面に表示されるようにする
- 手動で動作に問題ないことを確認

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/c1e8ed9b-7988-4a1c-bef7-2af8ae99cd36

