### PR TITLE
Dictionary詳細画面のN+1問題対応

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -38,70 +38,71 @@ class DictionariesController < ApplicationController
 		respond_to do |format|
 			page = (params[:page].presence || 1).to_i
 			per  = (params[:per].presence || 15).to_i
+			entries_with_tags = @dictionary.entries.includes(:tags)
 
 			format.html {
 				@entries, @type_entries = if params[:label_search]
 					params[:label_search].strip!
-					[@dictionary.narrow_entries_by_label(params[:label_search], page, per).includes(:tags), "Active"]
+					[@dictionary.narrow_entries_by_label(entries_with_tags, params[:label_search], page, per), "Active"]
 				elsif params[:id_search]
 					params[:id_search].strip!
-					[@dictionary.narrow_entries_by_identifier(params[:id_search], page, per).includes(:tags), "Active"]
+					[@dictionary.narrow_entries_by_identifier(entries_with_tags, params[:id_search], page, per), "Active"]
 				elsif params[:tag_search]
 					tag_id = params[:tag_search].to_i
-					[@dictionary.narrow_entries_by_tag(tag_id, page, per).includes(:tags), "Active"]
+					[@dictionary.narrow_entries_by_tag(entries_with_tags, tag_id, page, per), "Active"]
 				else
 					if params[:mode].present?
 						case params[:mode].to_i
 						when EntryMode::WHITE
-							[@dictionary.entries.white.simple_paginate(page, per).includes(:tags), "White"]
+							[entries_with_tags.white.simple_paginate(page, per), "White"]
 						when EntryMode::BLACK
-							[@dictionary.entries.black.simple_paginate(page, per).includes(:tags), "Black"]
+							[entries_with_tags.black.simple_paginate(page, per), "Black"]
 						when EntryMode::GRAY
-							[@dictionary.entries.gray.simple_paginate(page, per).includes(:tags), "Gray"]
+							[entries_with_tags.gray.simple_paginate(page, per), "Gray"]
 						when EntryMode::ACTIVE
-							[@dictionary.entries.active.simple_paginate(page, per).includes(:tags), "Active"]
+							[entries_with_tags.active.simple_paginate(page, per), "Active"]
 						when EntryMode::CUSTOM
-							[@dictionary.entries.custom.simple_paginate(page, per).includes(:tags), "Custom"]
+							[entries_with_tags.custom.simple_paginate(page, per), "Custom"]
 						when EntryMode::AUTO_EXPANDED
-							[@dictionary.entries.auto_expanded.simple_paginate(page, per).includes(:tags), "Auto expanded"]
+							[entries_with_tags.auto_expanded.simple_paginate(page, per), "Auto expanded"]
 						else
-							[@dictionary.entries.active.simple_paginate(page, per).includes(:tags), "Active"]
+							[entries_with_tags.active.simple_paginate(page, per), "Active"]
 						end
 					else
-						[@dictionary.entries.active.simple_paginate(page, per).load_async.includes(:tags), "Active"]
+						[entries_with_tags.active.simple_paginate(page, per).load_async, "Active"]
 					end
 				end
 			}
 			format.tsv  {
 				entries, suffix = if params[:label_search]
 					params[:label_search].strip!
-					[@dictionary.narrow_entries_by_label(params[:label_search]).includes(:tags), "label_search_#{params[:label_search]}"]
+					[@dictionary.narrow_entries_by_label(entries_with_tags, params[:label_search]), "label_search_#{params[:label_search]}"]
 				elsif params[:id_search]
 					params[:id_search].strip!
-					[@dictionary.narrow_entries_by_identifier(params[:id_search]).includes(:tags), "id_search_#{params[:id_search]}"]
+					[@dictionary.narrow_entries_by_identifier(entries_with_tags, params[:id_search]), "id_search_#{params[:id_search]}"]
 				elsif params[:tag_search]
 					tag_id = params[:tag_search].to_i
-					[@dictionary.narrow_entries_by_tag(tag_id, page, per).includes(:tags), "tag_search_#{params[:tag_search]}"]
+					[@dictionary.narrow_entries_by_tag(entries_with_tags, tag_id, page, per), "tag_search_#{params[:tag_search]}"]
 				else
 					if params[:mode].present?
 						case params[:mode].to_i
 						when EntryMode::WHITE
-							[@dictionary.entries.added.includes(:tags), "white"]
+							[entries_with_tags.added, "white"]
 						when EntryMode::BLACK
-							[@dictionary.entries.deleted.includes(:tags), "black"]
+							[entries_with_tags.deleted, "black"]
 						when EntryMode::GRAY
-							[@dictionary.entries.gray.includes(:tags), "gray"]
+							[entries_with_tags.gray, "gray"]
 						when EntryMode::ACTIVE
-							[@dictionary.entries.active.includes(:tags), nil]
+							[entries_with_tags.active, nil]
 						when EntryMode::CUSTOM
-							[@dictionary.entries.custom.includes(:tags), "custom"]
+							[entries_with_tags.custom, "custom"]
 						when EntryMode::AUTO_EXPANDED
-							[@dictionary.entries.auto_expanded.includes(:tags), "auto expanded"]
+							[entries_with_tags.auto_expanded, "auto expanded"]
 						else
-							[@dictionary.entries.active.includes(:tags), nil]
+							[entries_with_tags.active, nil]
 						end
 					else
-						[@dictionary.entries.active.includes(:tags), nil]
+						[entries_with_tags.active, nil]
 					end
 				end
 

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -42,66 +42,66 @@ class DictionariesController < ApplicationController
 			format.html {
 				@entries, @type_entries = if params[:label_search]
 					params[:label_search].strip!
-					[@dictionary.narrow_entries_by_label(params[:label_search], page, per), "Active"]
+					[@dictionary.narrow_entries_by_label(params[:label_search], page, per).includes(:tags), "Active"]
 				elsif params[:id_search]
 					params[:id_search].strip!
-					[@dictionary.narrow_entries_by_identifier(params[:id_search], page, per), "Active"]
+					[@dictionary.narrow_entries_by_identifier(params[:id_search], page, per).includes(:tags), "Active"]
 				elsif params[:tag_search]
 					tag_id = params[:tag_search].to_i
-					[@dictionary.narrow_entries_by_tag(tag_id, page, per), "Active"]
+					[@dictionary.narrow_entries_by_tag(tag_id, page, per).includes(:tags), "Active"]
 				else
 					if params[:mode].present?
 						case params[:mode].to_i
 						when EntryMode::WHITE
-							[@dictionary.entries.white.simple_paginate(page, per), "White"]
+							[@dictionary.entries.white.simple_paginate(page, per).includes(:tags), "White"]
 						when EntryMode::BLACK
-							[@dictionary.entries.black.simple_paginate(page, per), "Black"]
+							[@dictionary.entries.black.simple_paginate(page, per).includes(:tags), "Black"]
 						when EntryMode::GRAY
-							[@dictionary.entries.gray.simple_paginate(page, per), "Gray"]
+							[@dictionary.entries.gray.simple_paginate(page, per).includes(:tags), "Gray"]
 						when EntryMode::ACTIVE
-							[@dictionary.entries.active.simple_paginate(page, per), "Active"]
+							[@dictionary.entries.active.simple_paginate(page, per).includes(:tags), "Active"]
 						when EntryMode::CUSTOM
-							[@dictionary.entries.custom.simple_paginate(page, per), "Custom"]
+							[@dictionary.entries.custom.simple_paginate(page, per).includes(:tags), "Custom"]
 						when EntryMode::AUTO_EXPANDED
-							[@dictionary.entries.auto_expanded.simple_paginate(page, per), "Auto expanded"]
+							[@dictionary.entries.auto_expanded.simple_paginate(page, per).includes(:tags), "Auto expanded"]
 						else
-							[@dictionary.entries.active.simple_paginate(page, per), "Active"]
+							[@dictionary.entries.active.simple_paginate(page, per).includes(:tags), "Active"]
 						end
 					else
-						[@dictionary.entries.active.simple_paginate(page, per).load_async, "Active"]
+						[@dictionary.entries.active.simple_paginate(page, per).load_async.includes(:tags), "Active"]
 					end
 				end
 			}
 			format.tsv  {
 				entries, suffix = if params[:label_search]
 					params[:label_search].strip!
-					[@dictionary.narrow_entries_by_label(params[:label_search]), "label_search_#{params[:label_search]}"]
+					[@dictionary.narrow_entries_by_label(params[:label_search]).includes(:tags), "label_search_#{params[:label_search]}"]
 				elsif params[:id_search]
 					params[:id_search].strip!
-					[@dictionary.narrow_entries_by_identifier(params[:id_search]), "id_search_#{params[:id_search]}"]
+					[@dictionary.narrow_entries_by_identifier(params[:id_search]).includes(:tags), "id_search_#{params[:id_search]}"]
 				elsif params[:tag_search]
 					tag_id = params[:tag_search].to_i
-					[@dictionary.narrow_entries_by_tag(tag_id, page, per), "tag_search_#{params[:tag_search]}"]
+					[@dictionary.narrow_entries_by_tag(tag_id, page, per).includes(:tags), "tag_search_#{params[:tag_search]}"]
 				else
 					if params[:mode].present?
 						case params[:mode].to_i
 						when EntryMode::WHITE
-							[@dictionary.entries.added, "white"]
+							[@dictionary.entries.added.includes(:tags), "white"]
 						when EntryMode::BLACK
-							[@dictionary.entries.deleted, "black"]
+							[@dictionary.entries.deleted.includes(:tags), "black"]
 						when EntryMode::GRAY
-							[@dictionary.entries.gray, "gray"]
+							[@dictionary.entries.gray.includes(:tags), "gray"]
 						when EntryMode::ACTIVE
-							[@dictionary.entries.active, nil]
+							[@dictionary.entries.active.includes(:tags), nil]
 						when EntryMode::CUSTOM
-							[@dictionary.entries.custom, "custom"]
+							[@dictionary.entries.custom.includes(:tags), "custom"]
 						when EntryMode::AUTO_EXPANDED
-							[@dictionary.entries.auto_expanded, "auto expanded"]
+							[@dictionary.entries.auto_expanded.includes(:tags), "auto expanded"]
 						else
-							[@dictionary.entries.active, nil]
+							[@dictionary.entries.active.includes(:tags), nil]
 						end
 					else
-						[@dictionary.entries.active, nil]
+						[@dictionary.entries.active.includes(:tags), nil]
 					end
 				end
 

--- a/app/controllers/lookup_controller.rb
+++ b/app/controllers/lookup_controller.rb
@@ -131,7 +131,7 @@ class LookupController < ApplicationController
 
 			entries = if params[:term]
 				page = params[:page] || 0
-				dictionary.narrow_entries_by_label(params[:term], page, params[:per_page])
+				dictionary.narrow_entries_by_label(entries, params[:term], page, params[:per_page])
 			end
 
 			respond_to do |format|

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -334,7 +334,7 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def narrow_entries_by_label(str, page = 0, per = nil)
+	def narrow_entries_by_label(entries, str, page = 0, per = nil)
 		norm1 = normalize1(str)
 		if per.nil?
 			entries.where("norm1 LIKE ?", "%#{norm1}%").order(:label_length).page(page)
@@ -363,7 +363,7 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def narrow_entries_by_identifier(str, page = 0, per = nil)
+	def narrow_entries_by_identifier(entries, str, page = 0, per = nil)
 		if per.nil?
 			entries.where("identifier ILIKE ?", "%#{str}%").page(page)
 		else
@@ -371,7 +371,7 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def narrow_entries_by_tag(tag_id, page = 0, per = nil)
+	def narrow_entries_by_tag(entries, tag_id, page = 0, per = nil)
 		if per.nil?
 			entries.joins(:tags).where(tags: { id: tag_id }).page(page)
 		else


### PR DESCRIPTION
close #96 
Dictionary詳細画面のN+1問題対応が完了しましたので、ご確認よろしくお願いいたします。

# 実施したこと
- Entry-Tagsの部分がN+1問題を起こしていたので、Entries読み込みの際にincludes(:tags)で読み込んでおくことで対応した

## 実行前後のログ
スクショのように7つのデータを読み込んで表示する部分で、修正前後のログを確認
- 修正前
```
  [1m[36mTag Pluck (0.1ms)[0m  [1m[34mSELECT "tags"."value", "tags"."id" FROM "tags" WHERE "tags"."dictionary_id" = $1[0m  [["dictionary_id", 23]]
  ↳ app/views/entries/_table.html.erb:58
  Rendered entries/_colgroup.erb (Duration: 0.0ms | Allocations: 12)
  [1m[36mTag Load (0.9ms)[0m  [1m[34mSELECT "tags".* FROM "tags" INNER JOIN "entry_tags" ON "tags"."id" = "entry_tags"."tag_id" WHERE "entry_tags"."entry_id" = $1[0m  [["entry_id", 92946]]
  ↳ app/views/entries/_entry.html.erb:30
  [1m[36mTag Load (0.2ms)[0m  [1m[34mSELECT "tags".* FROM "tags" INNER JOIN "entry_tags" ON "tags"."id" = "entry_tags"."tag_id" WHERE "entry_tags"."entry_id" = $1[0m  [["entry_id", 92947]]
  ↳ app/views/entries/_entry.html.erb:30
  [1m[36mTag Load (0.1ms)[0m  [1m[34mSELECT "tags".* FROM "tags" INNER JOIN "entry_tags" ON "tags"."id" = "entry_tags"."tag_id" WHERE "entry_tags"."entry_id" = $1[0m  [["entry_id", 92949]]
  ↳ app/views/entries/_entry.html.erb:30
  [1m[36mTag Load (0.2ms)[0m  [1m[34mSELECT "tags".* FROM "tags" INNER JOIN "entry_tags" ON "tags"."id" = "entry_tags"."tag_id" WHERE "entry_tags"."entry_id" = $1[0m  [["entry_id", 92950]]
  ↳ app/views/entries/_entry.html.erb:30
  [1m[36mTag Load (0.2ms)[0m  [1m[34mSELECT "tags".* FROM "tags" INNER JOIN "entry_tags" ON "tags"."id" = "entry_tags"."tag_id" WHERE "entry_tags"."entry_id" = $1[0m  [["entry_id", 92951]]
  ↳ app/views/entries/_entry.html.erb:30
  [1m[36mTag Load (0.2ms)[0m  [1m[34mSELECT "tags".* FROM "tags" INNER JOIN "entry_tags" ON "tags"."id" = "entry_tags"."tag_id" WHERE "entry_tags"."entry_id" = $1[0m  [["entry_id", 92952]]
  ↳ app/views/entries/_entry.html.erb:30
  [1m[36mTag Load (0.1ms)[0m  [1m[34mSELECT "tags".* FROM "tags" INNER JOIN "entry_tags" ON "tags"."id" = "entry_tags"."tag_id" WHERE "entry_tags"."entry_id" = $1[0m  [["entry_id", 92948]]
  ↳ app/views/entries/_entry.html.erb:30
  Rendered collection of entries/_entry.html.erb [7 times] (Duration: 13.9ms | Allocations: 13650)
  [1m[36mTag Load (0.1ms)[0m  [1m[34mSELECT "tags".* FROM "tags" WHERE "tags"."dictionary_id" = $1[0m  [["dictionary_id", 23]]
  ↳ app/views/entries/_table.html.erb:151
```

- 修正後
```
  [1m[36mTag Pluck (0.6ms)[0m  [1m[34mSELECT "tags"."value", "tags"."id" FROM "tags" WHERE "tags"."dictionary_id" = $1[0m  [["dictionary_id", 23]]
  ↳ app/views/entries/_table.html.erb:58
  Rendered entries/_colgroup.erb (Duration: 0.0ms | Allocations: 11)
  [1m[36mCACHE Entry Load (0.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."dictionary_id" = $1 AND "entries"."mode" IN ($2, $3) LIMIT $4 OFFSET $5[0m  [["dictionary_id", 23], ["mode", 0], ["mode", 1], ["LIMIT", 15], ["OFFSET", 0]]
  ↳ app/views/entries/_table.html.erb:82
  [1m[36mEntryTag Load (0.8ms)[0m  [1m[34mSELECT "entry_tags".* FROM "entry_tags" WHERE "entry_tags"."entry_id" IN ($1, $2, $3, $4, $5, $6, $7)[0m  [["entry_id", 92946], ["entry_id", 92947], ["entry_id", 92949], ["entry_id", 92950], ["entry_id", 92951], ["entry_id", 92952], ["entry_id", 92948]]
  ↳ app/views/entries/_table.html.erb:82
  [1m[36mTag Load (0.4ms)[0m  [1m[34mSELECT "tags".* FROM "tags" WHERE "tags"."id" IN ($1, $2, $3)[0m  [["id", 67], ["id", 68], ["id", 69]]
  ↳ app/views/entries/_table.html.erb:82
  Rendered collection of entries/_entry.html.erb [7 times] (Duration: 15.5ms | Allocations: 4133)
  [1m[36mTag Load (0.3ms)[0m  [1m[34mSELECT "tags".* FROM "tags" WHERE "tags"."dictionary_id" = $1[0m  [["dictionary_id", 23]]
  ↳ app/views/entries/_table.html.erb:151
```

（ログ全文）
[before_development.log](https://github.com/pubannotation/pubdictionaries/files/14533828/before_development.log)
[after_development.log](https://github.com/pubannotation/pubdictionaries/files/14533829/after_development.log)
