### PR TITLE
絞り込みメソッドをscope化

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -43,13 +43,13 @@ class DictionariesController < ApplicationController
 			format.html {
 				@entries, @type_entries = if params[:label_search]
 					params[:label_search].strip!
-					[@dictionary.narrow_entries_by_label(entries_with_tags, params[:label_search], page, per), "Active"]
+					[entries_with_tags.narrow_by_label(params[:label_search], page, per), "Active"]
 				elsif params[:id_search]
 					params[:id_search].strip!
-					[@dictionary.narrow_entries_by_identifier(entries_with_tags, params[:id_search], page, per), "Active"]
+					[entries_with_tags.narrow_by_identifier(params[:id_search], page, per), "Active"]
 				elsif params[:tag_search]
 					tag_id = params[:tag_search].to_i
-					[@dictionary.narrow_entries_by_tag(entries_with_tags, tag_id, page, per), "Active"]
+					[entries_with_tags.narrow_by_tag(tag_id, page, per), "Active"]
 				else
 					if params[:mode].present?
 						case params[:mode].to_i
@@ -72,17 +72,18 @@ class DictionariesController < ApplicationController
 						[entries_with_tags.active.simple_paginate(page, per).load_async, "Active"]
 					end
 				end
+			puts "@entries = #{@entries.inspect}"
 			}
 			format.tsv  {
 				entries, suffix = if params[:label_search]
 					params[:label_search].strip!
-					[@dictionary.narrow_entries_by_label(entries_with_tags, params[:label_search]), "label_search_#{params[:label_search]}"]
+					[entries_with_tags.narrow_by_label(params[:label_search]), "label_search_#{params[:label_search]}"]
 				elsif params[:id_search]
 					params[:id_search].strip!
-					[@dictionary.narrow_entries_by_identifier(entries_with_tags, params[:id_search]), "id_search_#{params[:id_search]}"]
+					[entries_with_tags.narrow_by_identifier(params[:id_search]), "id_search_#{params[:id_search]}"]
 				elsif params[:tag_search]
 					tag_id = params[:tag_search].to_i
-					[@dictionary.narrow_entries_by_tag(entries_with_tags, tag_id, page, per), "tag_search_#{params[:tag_search]}"]
+					[entries_with_tags.narrow_by_tag(tag_id, page, per), "tag_search_#{params[:tag_search]}"]
 				else
 					if params[:mode].present?
 						case params[:mode].to_i

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -72,7 +72,6 @@ class DictionariesController < ApplicationController
 						[entries_with_tags.active.simple_paginate(page, per).load_async, "Active"]
 					end
 				end
-			puts "@entries = #{@entries.inspect}"
 			}
 			format.tsv  {
 				entries, suffix = if params[:label_search]

--- a/app/controllers/lookup_controller.rb
+++ b/app/controllers/lookup_controller.rb
@@ -131,7 +131,7 @@ class LookupController < ApplicationController
 
 			entries = if params[:term]
 				page = params[:page] || 0
-				dictionary.narrow_entries_by_label(entries, params[:term], page, params[:per_page])
+				dictionary.narrow_entries_by_label(params[:term], page, params[:per_page])
 			end
 
 			respond_to do |format|

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -334,7 +334,7 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def narrow_entries_by_label(entries, str, page = 0, per = nil)
+	def narrow_entries_by_label(str, page = 0, per = nil)
 		norm1 = normalize1(str)
 		if per.nil?
 			entries.where("norm1 LIKE ?", "%#{norm1}%").order(:label_length).page(page)
@@ -360,22 +360,6 @@ class Dictionary < ApplicationRecord
 		else
 			entries.where("norm1 LIKE ?", "#{norm1}%").order(:label_length).page(page).per(per) +
 			entries.where("norm1 LIKE ?", "_%#{norm1}%").order(:label_length).page(page).per(per)
-		end
-	end
-
-	def narrow_entries_by_identifier(entries, str, page = 0, per = nil)
-		if per.nil?
-			entries.where("identifier ILIKE ?", "%#{str}%").page(page)
-		else
-			entries.where("identifier ILIKE ?", "%#{str}%").page(page).per(per)
-		end
-	end
-
-	def narrow_entries_by_tag(entries, tag_id, page = 0, per = nil)
-		if per.nil?
-			entries.joins(:tags).where(tags: { id: tag_id }).page(page)
-		else
-			entries.joins(:tags).where(tags: { id: tag_id }).page(page).per(per)
 		end
 	end
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -60,6 +60,24 @@ class Entry < ApplicationRecord
     offset(offset).limit(per)
   }
 
+  scope :narrow_by_label, -> (str, page = 0, per = nil) {
+    norm1 = Dictionary.normalize1(str)
+    puts "norm1 = #{norm1}"
+    query = where("norm1 LIKE ?", "%#{norm1}%").order(:label_length)
+    puts "query = #{query}"
+    per.nil? ? query.page(page) : query.page(page).per(per)
+  }
+
+  scope :narrow_by_identifier, -> (str, page = 0, per = nil) {
+    query = where("identifier ILIKE ?", "%#{str}%")
+    per.nil? ? query.page(page) : query.page(page).per(per)
+  }
+
+  scope :narrow_by_tag, -> (tag_id, page = 0, per = nil) {
+    query = joins(:tags).where(tags: { id: tag_id })
+    per.nil? ? query.page(page) : query.page(page).per(per)
+  }
+
   def to_s
     "('#{label}', '#{identifier}')"
   end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -62,9 +62,7 @@ class Entry < ApplicationRecord
 
   scope :narrow_by_label, -> (str, page = 0, per = nil) {
     norm1 = Dictionary.normalize1(str)
-    puts "norm1 = #{norm1}"
     query = where("norm1 LIKE ?", "%#{norm1}%").order(:label_length)
-    puts "query = #{query}"
     per.nil? ? query.page(page) : query.page(page).per(per)
   }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,6 +36,7 @@ ActiveRecord::Base.transaction do
   entry_items.each do |entry_def|
     entry = dictionary.entries.find_or_create_by!(
       label: entry_def[:label],
+      norm1: Dictionary.normalize1(entry_def[:label]),
       identifier: entry_def[:identifier],
       mode: entry_def[:mode],
       score: entry_def[:score]


### PR DESCRIPTION
close #100 
絞り込みメソッドのscope化が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Dictionary詳細画面におけるlabel, identifier, tagの絞り込み処理をscope化し、`entries_with_tags = @dictionary.entries.includes(:tags)`と接続するため、Entryモデルに移動させた
- Dictionaryモデルに定義していたメソッドのうち、
  - labelのみ別の箇所で使用していたので、前PRで修正する前の状態に戻した
  - identifier, tagは使用しなくなったので削除
- Dictionary#showでの記述をscopeに合わせて修正
- labelの検索テストが出来なかったため、seedファイルでnorm1カラムを追加

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/7e6db34a-0200-4d44-a223-5f36a8d0941b
