### PR TITLE
絞り込みメソッドをscope化(lookup)

### DIFF
--- a/app/controllers/lookup_controller.rb
+++ b/app/controllers/lookup_controller.rb
@@ -107,7 +107,7 @@ class LookupController < ApplicationController
 
 			entries = if params[:term]
 				page = params[:page] || 0
-				dictionary.narrow_entries_by_label_prefix(params[:term], page, params[:per_page])
+				dictionary.entries.narrow_by_label_prefix(params[:term], page, params[:per_page])
 			end
 
 			respond_to do |format|
@@ -131,7 +131,7 @@ class LookupController < ApplicationController
 
 			entries = if params[:term]
 				page = params[:page] || 0
-				dictionary.narrow_entries_by_label(params[:term], page, params[:per_page])
+				dictionary.entries.narrow_by_label(params[:term], page, params[:per_page])
 			end
 
 			respond_to do |format|
@@ -155,7 +155,7 @@ class LookupController < ApplicationController
 
 			entries = if params[:term]
 				page = params[:page] || 0
-				dictionary.narrow_entries_by_label_prefix_and_substring(params[:term], page, params[:per_page])
+				dictionary.entries.narrow_by_label_prefix_and_substring(params[:term], page, params[:per_page])
 			end
 
 			respond_to do |format|

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -334,35 +334,6 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def narrow_entries_by_label(str, page = 0, per = nil)
-		norm1 = normalize1(str)
-		if per.nil?
-			entries.where("norm1 LIKE ?", "%#{norm1}%").order(:label_length).page(page)
-		else
-			entries.where("norm1 LIKE ?", "%#{norm1}%").order(:label_length).page(page).per(per)
-		end
-	end
-
-	def narrow_entries_by_label_prefix(str, page = 0, per = nil)
-		norm1 = normalize1(str)
-		if per.nil?
-			entries.where("norm1 LIKE ?", "#{norm1}%").order(:label_length).page(page)
-		else
-			entries.where("norm1 LIKE ?", "#{norm1}%").order(:label_length).page(page).per(per)
-		end
-	end
-
-	def narrow_entries_by_label_prefix_and_substring(str, page = 0, per = nil)
-		norm1 = normalize1(str)
-		if per.nil?
-			entries.where("norm1 LIKE ?", "#{norm1}%").order(:label_length).page(page) +
-			entries.where("norm1 LIKE ?", "_%#{norm1}%").order(:label_length).page(page)
-		else
-			entries.where("norm1 LIKE ?", "#{norm1}%").order(:label_length).page(page).per(per) +
-			entries.where("norm1 LIKE ?", "_%#{norm1}%").order(:label_length).page(page).per(per)
-		end
-	end
-
 	def self.narrow_entries_by_identifier(str, page = 0, per = nil)
 		if per.nil?
 			Entry.where("identifier ILIKE ?", "%#{str}%").page(page)

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -334,24 +334,6 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def self.narrow_entries_by_identifier(str, page = 0, per = nil)
-		if per.nil?
-			Entry.where("identifier ILIKE ?", "%#{str}%").page(page)
-		else
-			Entry.where("identifier ILIKE ?", "%#{str}%").page(page).per(per)
-		end
-	end
-
-	def self.narrow_entries_by_label(str, page = 0)
-		norm1 = normalize1(str)
-		Entry.where("norm1 LIKE ?", "#{norm1}%").order(:label_length).page(page)
-	end
-
-	def self.narrow_entries_by_label_prefix(str, page = 0)
-		norm1 = normalize1(str)
-		Entry.where("norm1 LIKE ?", "#{norm1}%").order(:label_length).page(page)
-	end
-
 	def self.search_term_order(dictionaries, ssdbs, threshold, term, norm1 = nil, norm2 = nil)
 		return [] if term.empty?
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -67,6 +67,18 @@ class Entry < ApplicationRecord
     per.nil? ? query.page(page) : query.page(page).per(per)
   }
 
+  scope :narrow_by_label_prefix, -> (str, page = 0, per = nil) {
+    norm1 = Dictionary.normalize1(str)
+    query = where("norm1 LIKE ?", "%#{norm1}%").order(:label_length)
+    per.nil? ? query.page(page) : query.page(page).per(per)
+  }
+
+  scope :narrow_by_label_prefix_and_substring, -> (str, page = 0, per = nil) {
+    norm1 = Dictionary.normalize1(str)
+    query = where("norm1 LIKE ? OR norm1 LIKE ?", "#{norm1}%", "_%#{norm1}%").order(:label_length)
+    per.nil? ? query.page(page) : query.page(page).per(per)
+  }
+
   scope :narrow_by_identifier, -> (str, page = 0, per = nil) {
     query = where("identifier ILIKE ?", "%#{str}%")
     per.nil? ? query.page(page) : query.page(page).per(per)


### PR DESCRIPTION
close #103
絞り込みメソッドをscope化(lookup)が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Dictionaryモデルで定義しているメソッドをscope化。目的(対象)はEntryの絞り込みのため、Entryモデルに移動
- Dictionaryモデルで定義している絞り込みメソッドのうち、どこにも使われていないものを削除
- 手動で確認し、問題なく動作することを確認

## look-up APIの説明
https://docs.pubdictionaries.org/lookup-api/

## 実行結果
今回編集したscopeを使用している`substring_completion`、`prefix_completion`、`mixed_completion`を実行

https://github.com/pubannotation/pubdictionaries/assets/149556430/cac60175-01fd-4de6-9e45-38b897fe19fb


