### PR TITLE
類義語自動拡張の対象をwhite,grayのみに変更

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -464,11 +464,11 @@ class Dictionary < ApplicationRecord
     batch_size = 1000
     processed_identifiers = Set.new
 
-    identifiers_count =  entries.without_black.select(:identifier).distinct.count
+    identifiers_count =  entries.active.select(:identifier).distinct.count
     batch_count = identifiers_count / batch_size
 
     0.upto(batch_count) do |i|
-      current_batch = entries.without_black
+      current_batch = entries.active
                               .select(:identifier)
                               .distinct
                               .order(:identifier)

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -478,7 +478,7 @@ class Dictionary < ApplicationRecord
 
       new_identifiers = current_batch.reject { |identifier| processed_identifiers.include?(identifier) }
       new_identifiers.each do |identifier|
-        synonyms = entries.without_black
+        synonyms = entries.active
                           .where(identifier: identifier)
                           .where("created_at < ?", start_time)
                           .pluck(:label)


### PR DESCRIPTION
close #104 
類義語自動拡張の対象の変更が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- `synonym_expansion`関数に通すEntryの対象を`Black以外`→`White or Gray (=activeモード)`に変更
- 手動で、対象モードのEntryのみが自動拡張されることを確認

## 実行結果
White + Gray = 7
Auto expanded = 21　→Expand synonym→　28（White + Grayの分だけ拡張されている）

https://github.com/pubannotation/pubdictionaries/assets/149556430/db111f06-ef34-43e8-af0b-8cc4437b6a23

