### PR TITLE
類義語のwhite確定を複数一括選択化

### DIFF
--- a/app/assets/stylesheets/entries.scss
+++ b/app/assets/stylesheets/entries.scss
@@ -31,6 +31,16 @@ table.entries {
   .col_button {
     width: 30px;
   }
+
+  .col_double_button {
+    width: 50px;
+  }
+
+  .buttons-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }
 
 .entries td {

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -139,10 +139,12 @@ class EntriesController < ApplicationController
 		dictionary = Dictionary.editable(current_user).find_by_name(params[:dictionary_id])
 		raise ArgumentError, "Cannot find the dictionary" if dictionary.nil?
 
-		entry = Entry.find(params[:id])
-		raise ArgumentError, "Cannot find the entry" if entry.nil?
+		raise ArgumentError, "No entry to be confirmed is selected" unless params[:entry_id].present?
 
-		dictionary.confirm_entry(entry)
+		ActiveRecord::Base.transaction do
+			entries = Entry.where(id: params[:entry_id])
+			entries.each{|entry| dictionary.confirm_entry(entry)}
+		end
 
 		respond_to do |format|
 			format.html{

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -141,10 +141,7 @@ class EntriesController < ApplicationController
 
 		raise ArgumentError, "No entry to be confirmed is selected" unless params[:entry_id].present?
 
-		ActiveRecord::Base.transaction do
-			entries = Entry.where(id: params[:entry_id])
-			entries.each{|entry| dictionary.confirm_entry(entry)}
-		end
+		dictionary.confirm_entries(params[:entry_id])
 
 		respond_to do |format|
 			format.html{

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -165,9 +165,10 @@ class Dictionary < ApplicationRecord
 		end
 	end
 
-	def confirm_entry(entry)
+	def confirm_entries(entry_ids)
 		transaction do
-			entry.be_white!
+			entries = Entry.where(id: entry_ids)
+			entries.each{ |entry| entry.be_white! }
 			update_entries_num
 		end
 	end

--- a/app/views/entries/_colgroup.erb
+++ b/app/views/entries/_colgroup.erb
@@ -6,7 +6,6 @@
     <col class="col_button">
     <% if type_entries == 'Auto expanded' %>
       <col class="col_score">
-      <col class="col_button">
     <% end %>
     <% if dictionary.editable?(current_user) %>
       <col class="col_button">

--- a/app/views/entries/_colgroup.erb
+++ b/app/views/entries/_colgroup.erb
@@ -7,7 +7,9 @@
     <% if type_entries == 'Auto expanded' %>
       <col class="col_score">
     <% end %>
-    <% if dictionary.editable?(current_user) %>
-      <col class="col_button">
+    <% if dictionary.editable?(current_user) && @type_entries == 'Auto expanded' %>
+      <col class="col_double_button">
+    <% elsif @dictionary.editable?(current_user) %>
+    <col class="col_button">
     <% end %>
   </colgroup>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -38,9 +38,6 @@
     <td style="border-right-style: none">
       <%= entry.score %>
     </td>
-    <td style="border-right-style: none; text-align: center">
-      <%= link_to('<i class="fa-regular fa-circle-check"></i>'.html_safe, confirm_dictionary_entry_path(@dictionary, entry), method: :put, title: 'Auto expanded to white') %>
-    </td>
   <% end %>
   <% if @dictionary.editable?(current_user) %>
     <td style="text-align: center">

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -89,9 +89,7 @@
       <%= render partial: "entries/entry", collection: @entries -%>
 
       <tr>
-        <td style="border-style:none"></td>
-        <td colspan="2" style="border-style:none"></td>
-        <td colspan="2" style="border-style:none"></td>
+        <td colspan="5" style="border-style:none"></td>
         <% if ['Gray', 'Active'].include?(@type_entries) %>
           <td style="text-align:center">
             <a title="switch selected entries to black" href="javascript:{}" onclick="document.getElementById('switch_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -126,7 +126,7 @@
 function submitFormWithCheckedEntries(formId) {
   const form = document.getElementById(formId);
 
-  form.querySelectorAll(`input[name="entry_id[]"]`).forEach(input => input.remove());
+  form.querySelectorAll('input[name="entry_id[]"]').forEach(input => input.remove());
 
   document.querySelectorAll('.chkbox:checked').forEach(checkbox => {
     const input = document.createElement('input');

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -80,10 +80,10 @@
 </table>
 
 <% if @dictionary.editable?(current_user) %>
-  <% form_action_path = ['Gray', 'Active'].include?(@type_entries) ? switch_entries_dictionary_entries_path(@dictionary) : dictionary_entries_path(@dictionary) %>
-  <% form_method = ['Gray', 'Active'].include?(@type_entries) ? :put : :delete %>
-  <%= form_tag(form_action_path, method: form_method, id: "#{form_method == :put ? 'switch_entries_form' : 'delete_entries_form'}") do %>
+  <%= form_tag(confirm_dictionary_entries_path(@dictionary), method: :put, id: 'confirm_entries_form') do %><% end %>
+  <%= form_tag(dictionary_entries_path(@dictionary), method: :delete, id: 'delete_entries_form') do %><% end %>
 
+  <%= form_tag(switch_entries_dictionary_entries_path(@dictionary), method: :put, id: 'switch_entries_form') do %>
     <table class="entries" style="margin-top:0; margin-bottom:0">
       <%= render 'entries/colgroup', type_entries: @type_entries, dictionary: @dictionary %>
       <%= render partial: "entries/entry", collection: @entries -%>
@@ -97,8 +97,8 @@
         <% elsif ['Auto expanded'].include?(@type_entries) %>
           <td style="border-style:none"></td>
           <td style="text-align:center">
-            <a title="confirm to white" href="javascript:{}" onclick="if(confirm('Are you sure to confirm to white selected entries?')) { document.getElementById('confirm_entries_form').submit(); } return false;"><i class="fa-regular fa-circle-check"></i></a>
-            <a title="remove selected entries" href="javascript:{}" onclick="if(confirm('Are you sure to remove selected entries?')) { document.getElementById('delete_entries_form').submit(); } return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
+            <a title="confirm selected entries to white" href="javascript:{}" onclick="if(confirm('Are you sure to confirm to white selected entries?')) { submitFormWithCheckedEntries('confirm_entries_form'); } return false;"><i class="fa-regular fa-circle-check"></i></a>
+            <a title="remove selected entries" href="javascript:{}" onclick="if(confirm('Are you sure to remove selected entries?')) { submitFormWithCheckedEntries('delete_entries_form'); } return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
           </td>
         <% end %>
       </tr>
@@ -132,6 +132,22 @@
       lastChecked = this;
     });
   });
+
+function submitFormWithCheckedEntries(formId) {
+  const form = document.getElementById(formId);
+
+  document.querySelectorAll(`#${formId} input[name="entry_id[]"]`).forEach(input => input.remove());
+
+  document.querySelectorAll('.chkbox:checked').forEach(checkbox => {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'entry_id[]';
+    input.value = checkbox.value;
+    form.appendChild(input);
+  });
+
+  form.submit();
+}
 </script>
 
 <table class="entries" style="margin-top:2px">

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -35,7 +35,6 @@
     <col class="col_button">
     <% if @type_entries == 'Auto expanded' %>
       <col class="col_score">
-      <col class="col_button">
     <% end %>
     <% if @dictionary.editable?(current_user) %>
       <col class="col_button">
@@ -72,7 +71,6 @@
       </th>
       <% if @type_entries == 'Auto expanded' %>
         <th>Score</th>
-        <th style="border-right-style: none"></th>
       <% end %>
       <% if @dictionary.editable?(current_user) %>
         <th style="border-left-style: none"></th>
@@ -100,8 +98,8 @@
           </td>
         <% elsif ['Auto expanded'].include?(@type_entries) %>
           <td style="border-style:none"></td>
-          <td style="border-style:none"></td>
           <td style="text-align:center">
+            <a title="confirm to white" href="javascript:{}" onclick="if(confirm('Are you sure to confirm to white selected entries?')) { document.getElementById('confirm_entries_form').submit(); } return false;"><i class="fa-regular fa-circle-check"></i></a>
             <a title="remove selected entries" href="javascript:{}" onclick="if(confirm('Are you sure to remove selected entries?')) { document.getElementById('delete_entries_form').submit(); } return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
           </td>
         <% end %>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -27,19 +27,7 @@
 <% end %>
 
 <table class="entries" style="margin-bottom:0; border-bottom-style:none">
-  <colgroup>
-    <col class="col_label">
-    <col class="col_identifier">
-    <col class="col_button">
-    <col class="col_tags">
-    <col class="col_button">
-    <% if @type_entries == 'Auto expanded' %>
-      <col class="col_score">
-    <% end %>
-    <% if @dictionary.editable?(current_user) %>
-      <col class="col_button">
-    <% end %>
-  </colgroup>
+  <%= render 'entries/colgroup', type_entries: @type_entries, dictionary: @dictionary %>
   <thead>
     <tr>
       <th>
@@ -97,8 +85,10 @@
         <% elsif ['Auto expanded'].include?(@type_entries) %>
           <td style="border-style:none"></td>
           <td style="text-align:center">
-            <a title="confirm selected entries to white" href="javascript:{}" onclick="if(confirm('Are you sure to confirm to white selected entries?')) { submitFormWithCheckedEntries('confirm_entries_form'); } return false;"><i class="fa-regular fa-circle-check"></i></a>
-            <a title="remove selected entries" href="javascript:{}" onclick="if(confirm('Are you sure to remove selected entries?')) { submitFormWithCheckedEntries('delete_entries_form'); } return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
+            <div class="buttons-container">
+              <a title="confirm selected entries to white" href="javascript:{}" onclick="if(confirm('Are you sure to confirm to white selected entries?')) { submitFormWithCheckedEntries('confirm_entries_form'); } return false;"><i class="fa-regular fa-circle-check"></i></a>
+              /<a title="remove selected entries" href="javascript:{}" onclick="if(confirm('Are you sure to remove selected entries?')) { submitFormWithCheckedEntries('delete_entries_form'); } return false;"><i class="fa fa-trash-can" aria-hidden="true"></i></a>
+            </div>
           </td>
         <% end %>
       </tr>
@@ -157,9 +147,12 @@ function submitFormWithCheckedEntries(formId) {
     <col class="col_tags">
     <% if @type_entries == 'Auto expanded' %>
       <col class="col_score">
+      <% if @dictionary.editable?(current_user) %>
+        <col class="col_double_button">
+      <% end %>
+    <% else %>
       <col class="col_button">
     <% end %>
-    <col class="col_button">
   </colgroup>
   <% if @dictionary.editable?(current_user) %>
     <%= form_tag(dictionary_entries_path(@dictionary), method: :post, id: "add_entry_form") do %>
@@ -174,7 +167,7 @@ function submitFormWithCheckedEntries(formId) {
           <span><%= select_tag :tags, options_from_collection_for_select(Tag.where(dictionary_id: @dictionary.id), 'id', 'value'), multiple: true, class: 'js-searchable', style: "box-sizing:content-box; width:100%"  %></span>
         </td>
         <% if @type_entries == 'Auto expanded' %>
-          <td colspan="2"></td>
+          <td></td>
         <% end %>
         <td style="text-align:center">
           <a title="add" href="javascript:{}" onclick="document.getElementById('add_entry_form').submit(); return false;"><i class="fa fa-plus-square" aria-hidden="true"></i></a>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -126,7 +126,7 @@
 function submitFormWithCheckedEntries(formId) {
   const form = document.getElementById(formId);
 
-  document.querySelectorAll(`#${formId} input[name="entry_id[]"]`).forEach(input => input.remove());
+  form.querySelectorAll(`input[name="entry_id[]"]`).forEach(input => input.remove());
 
   document.querySelectorAll('.chkbox:checked').forEach(checkbox => {
     const input = document.createElement('input');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,11 +63,11 @@ Rails.application.routes.draw do
         post 'tsv', to: 'entries#upload_tsv'
         put 'switch_entries', to: 'entries#switch_to_black_entries'
         delete '/', to: 'entries#destroy_entries'
+        put 'confirm', to: "entries#confirm_to_white"
       end
 
       member do
         put 'undo', to: "entries#undo"
-        put 'confirm', to: "entries#confirm_to_white"
       end
     end
 


### PR DESCRIPTION
close #105 
類義語のwhite確定を複数一括選択化が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 「○にチェック」アイコンの列を削除
- ゴミ箱アイコンの横に「○にチェック」アイコンを設置し、これを押下したらチェックされているEntryを一括でWhiteに確定するように仕様変更
- 同じ領域でForm_tagをputとdeleteで共存できなかったので、scriptでクリックされたボタンに応じてdestroy_entriesかconfirm_to_whiteにsubmit出来るように対応

## 実施していないこと
必要であれば別途対応したいと思います。
- scriptは前の慣習に沿って、jsファイルを作成するのではなくhtml.erb内に記載しました

## ビューの修正前後
修正前
![image](https://github.com/pubannotation/pubdictionaries/assets/149556430/90012f54-d400-4ed3-b947-f156f08da081)
修正後
<img width="154" alt="image" src="https://github.com/pubannotation/pubdictionaries/assets/149556430/f5241a90-27cf-4e13-bcca-b7a1c1a7bac3">

## 実行結果


https://github.com/pubannotation/pubdictionaries/assets/149556430/c4be7830-ee0f-45fb-a4df-f93ac30afecb

