### PR TITLE
ActiveとCustomの情報をダウンロードしたときのtsvファイルへのタグ列追加

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -109,9 +109,10 @@ class DictionariesController < ApplicationController
 				filename = @dictionary.name
 				filename += '_' + suffix if suffix
 				if params[:mode].to_i == EntryMode::CUSTOM
-					send_data entries.as_tsv_v,  filename: "#{filename}.tsv", type: :tsv
+					send_data Entry.as_tsv_v(entries),  filename: "#{filename}.tsv", type: :tsv
 				else
-					send_data entries.as_tsv,  filename: "#{filename}.tsv", type: :tsv
+					puts "entries: #{entries.inspect}"
+					send_data Entry.as_tsv(entries),  filename: "#{filename}.tsv", type: :tsv
 				end
 			}
 		end

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -109,10 +109,10 @@ class DictionariesController < ApplicationController
 				filename = @dictionary.name
 				filename += '_' + suffix if suffix
 				if params[:mode].to_i == EntryMode::CUSTOM
-					send_data Entry.as_tsv_v(entries),  filename: "#{filename}.tsv", type: :tsv
+					send_data entries.as_tsv_v, filename: "#{filename}.tsv", type: :tsv
 				else
 					puts "entries: #{entries.inspect}"
-					send_data Entry.as_tsv(entries),  filename: "#{filename}.tsv", type: :tsv
+					send_data entries.as_tsv, filename: "#{filename}.tsv", type: :tsv
 				end
 			}
 		end

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -111,7 +111,6 @@ class DictionariesController < ApplicationController
 				if params[:mode].to_i == EntryMode::CUSTOM
 					send_data entries.as_tsv_v, filename: "#{filename}.tsv", type: :tsv
 				else
-					puts "entries: #{entries.inspect}"
 					send_data entries.as_tsv, filename: "#{filename}.tsv", type: :tsv
 				end
 			}

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -100,20 +100,20 @@ class Entry < ApplicationRecord
     }
   end
 
-  def self.as_tsv(entries)
+  def self.as_tsv
     CSV.generate(col_sep: "\t") do |tsv|
       tsv << ['#label', :id, '#tags']
-      entries.each do |entry|
+      all.each do |entry|
         tags = entry.tags.map(&:value).join('|')
         tsv << [entry.label, entry.identifier, tags]
       end
     end
   end
 
-  def self.as_tsv_v(entries)
+  def self.as_tsv_v
     CSV.generate(col_sep: "\t") do |tsv|
       tsv << ['#label', :id, '#tags', :operator]
-      entries.each do |entry|
+      all.each do |entry|
         tags = entry.tags.map(&:value).join('|')
         operator = case entry.mode
         when EntryMode::WHITE

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -100,20 +100,20 @@ class Entry < ApplicationRecord
     }
   end
 
-  def self.as_tsv
+  def self.as_tsv(entries)
     CSV.generate(col_sep: "\t") do |tsv|
       tsv << ['#label', :id, '#tags']
-      all.each do |entry|
+      entries.each do |entry|
         tags = entry.tags.map(&:value).join('|')
         tsv << [entry.label, entry.identifier, tags]
       end
     end
   end
 
-  def self.as_tsv_v
+  def self.as_tsv_v(entries)
     CSV.generate(col_sep: "\t") do |tsv|
       tsv << ['#label', :id, '#tags', :operator]
-      all.each do |entry|
+      entries.each do |entry|
         tags = entry.tags.map(&:value).join('|')
         operator = case entry.mode
         when EntryMode::WHITE

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -102,24 +102,26 @@ class Entry < ApplicationRecord
 
   def self.as_tsv
     CSV.generate(col_sep: "\t") do |tsv|
-      tsv << ['#label', :id]
+      tsv << ['#label', :id, '#tags']
       all.each do |entry|
-        tsv << [entry.label, entry.identifier]
+        tags = entry.tags.map(&:value).join('|')
+        tsv << [entry.label, entry.identifier, tags]
       end
     end
   end
 
   def self.as_tsv_v
     CSV.generate(col_sep: "\t") do |tsv|
-      tsv << ['#label', :id, :operator]
+      tsv << ['#label', :id, '#tags', :operator]
       all.each do |entry|
+        tags = entry.tags.map(&:value).join('|')
         operator = case entry.mode
         when EntryMode::WHITE
           '+'
         when EntryMode::BLACK
           '-'
         end
-        tsv << [entry.label, entry.identifier, operator]
+        tsv << [entry.label, entry.identifier, tags, operator]
       end
     end
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,8 +5,8 @@ class Tag < ApplicationRecord
 
   validates :value, length: {minimum: 3}, uniqueness: { scope: :dictionary_id }
   validates_format_of :value, # because of to_param overriding.
-                      :with => /\A[a-zA-Z_][a-zA-Z0-9_\- ()]*\z/,
-                      :message => "should begin with an alphabet or underscore, and only contain alphanumeric letters, underscore, hyphen, space, or round brackets!"
+                      :with => /\A[a-zA-Z_][a-zA-Z0-9_\-()]*\z/,
+                      :message => "should begin with an alphabet or underscore, and only contain alphanumeric letters, underscore, hyphen, or round brackets, without space!"
 
   def used_in_entries?
     entry_tags.exists?


### PR DESCRIPTION
close #106 
ActiveとCustomの情報をダウンロードしたときのtsvファイルへのタグ列追加が完了しましたので、ご確認よろしくお願いいたします。

# タグのバリデーション：空白を不許可
## 実施したこと
- tag.valueのバリデーションで空白を許可していたのを削除し、エラー時の文言も変更

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/b96f8436-f969-437f-b201-48e8b1497944


# tsvファイルへのタグ列追加
## 実施したこと
- tag列をidentifierの右に追加し、複数ある場合は'|'区切りで記載するように修正（active, custom両方とも）

## 実行結果
- Active
<img width="1015" alt="image" src="https://github.com/pubannotation/pubdictionaries/assets/149556430/b436a3d4-19ba-471d-bf0d-95f2ed15e377">
ダウンロードしたファイル(EntrezGene.tsv)の内容

```tsv
#label	id	#tags
Gray Mode Entry	1	Giraffe|Tiger|Elephant
Gray Mode Entry2	2	Giraffe|Elephant
White Mode Entry	1	Giraffe|Tiger|Elephant
White Mode Entry2	2	Elephant
White Mode Entry3	2	""
White Mode Entry4	3	Giraffe|Elephant
White Mode Entry5	4	""
```


- Custom
<img width="1021" alt="image" src="https://github.com/pubannotation/pubdictionaries/assets/149556430/e58208b1-1f29-48da-b0fa-e80dd5ba79ae">
ダウンロードしたファイル(EntrezGene_custom.tsv)の内容

```tsv
#label	id	#tags	operator
White Mode Entry	1	Giraffe|Tiger|Elephant	+
White Mode Entry2	2	Elephant	+
White Mode Entry3	2	""	+
White Mode Entry4	3	Giraffe|Elephant	+
White Mode Entry5	4	""	+
Black Mode Entry	3	Tiger|Elephant	-
Black Mode Entry2	1	""	-

```
