### PR TITLE
Dictionaryにassociated_annotation_projectカラム追加

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -387,7 +387,8 @@ class DictionariesController < ApplicationController
 			:associated_managers,
 			:tokens_len_min,
 			:tokens_len_max,
-			:threshold
+			:threshold,
+			:associated_annotation_project
 		)
 	end
 end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -23,8 +23,7 @@ class Dictionary < ApplicationRecord
 											:with => /\A[a-zA-Z_][a-zA-Z0-9_\- ()]*\z/,
 											:message => "should begin with an alphabet or underscore, and only contain alphanumeric letters, underscore, hyphen, space, or round brackets!"
 	validates :associated_annotation_project, presence: true,
-																						length: { minimum: 5, maximum: 40 },
-																						uniqueness: true
+																						length: { minimum: 5, maximum: 40 }
 	validates_format_of :associated_annotation_project, :with => /\A[a-z0-9\-_]+\z/i
 
 	DOWNLOADABLES_DIR = 'db/downloadables/'

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -22,6 +22,10 @@ class Dictionary < ApplicationRecord
 	validates_format_of :name,                              # because of to_param overriding.
 											:with => /\A[a-zA-Z_][a-zA-Z0-9_\- ()]*\z/,
 											:message => "should begin with an alphabet or underscore, and only contain alphanumeric letters, underscore, hyphen, space, or round brackets!"
+	validates :associated_annotation_project, presence: true,
+																						length: { minimum: 5, maximum: 40 },
+																						uniqueness: true
+	validates_format_of :associated_annotation_project, :with => /\A[a-z0-9\-_]+\z/i
 
 	DOWNLOADABLES_DIR = 'db/downloadables/'
 

--- a/app/views/dictionaries/_form.html.erb
+++ b/app/views/dictionaries/_form.html.erb
@@ -47,7 +47,7 @@
     </tr>
 
     <tr>
-      <th>Lisence</th>
+      <th>License</th>
       <td>
         <p class="note" style="margin-top:0">Please specify the license condition, which is important for proper and comfortable use of the dictionary. <a href="https://creativecommons.org/">Creative Commons</a> is a good source of various license conditions.</p>
         <table>
@@ -61,6 +61,13 @@
           </tr>
         </table>
       </td>
+    </tr>
+
+    <tr>
+      <th style="width: 6em;"><%= f.label :associated_annotation_project, "Associated Annotation Project" %></th>
+      <td>
+        <p class="note" style="margin-top:0">Please specify PubAnnotation's project linked to this dictionary if you have.</p>
+        <%= f.text_field :associated_annotation_project, required: true, style: "box-sizing: border-box; width:15em" %></td>
     </tr>
   </table>
 

--- a/db/migrate/20240314070046_add_associated_annotation_project_to_dictionaries.rb
+++ b/db/migrate/20240314070046_add_associated_annotation_project_to_dictionaries.rb
@@ -1,0 +1,5 @@
+class AddAssociatedAnnotationProjectToDictionaries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dictionaries, :associated_annotation_project, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_01_042744) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_14_070046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_042744) do
     t.float "threshold", default: 0.85
     t.string "language"
     t.integer "patterns_num", default: 0
+    t.string "associated_annotation_project"
     t.index ["user_id"], name: "index_dictionaries_on_user_id"
   end
 


### PR DESCRIPTION
close #107 
Dictionaryへのassociated_annotation_projectカラム追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- Dictionaryテーブルにassociated_annotation_projectカラムを追加
- バリデーションは[PubAnnotationのプロジェクトの名前](https://github.com/pubannotation/pubannotation/blob/1b19484ef01e5b1b3141d4e86e5681c4ba8f3a17/app/models/project.rb#L25-L26)と同じに設定
- Dictionary設定画面(新規、編集)にAssociated Annotation Projectプロパティの入力フォームを追加し、associated_annotation_projectを登録できるように設定

## 特記事項
- 入力フォームの説明文言は雰囲気で入力しましたので、確認依頼をお願いいたします。
- 現時点で、登録したassociated_annotation_projectをDictionary詳細画面などに表示するようにはしていません。
- 編集画面の"`License`"のつづりが間違っているところを見つけたので、ついでに直しておきました。

## 実行結果
成功するところ

https://github.com/pubannotation/pubdictionaries/assets/149556430/775a9cba-fd1b-4cdb-a25d-123457a4f7b7

バリデーションエラー

https://github.com/pubannotation/pubdictionaries/assets/149556430/ed0bd0e0-c2c9-4e8c-b9eb-4b1882dfcf26



