### PR TITLE
Entry一覧へのPubAnnotationリンク追加

### DIFF
--- a/app/helpers/entries_helper.rb
+++ b/app/helpers/entries_helper.rb
@@ -4,6 +4,17 @@ module EntriesHelper
   end
 
   def pub_annotation_search_url(entry, dictionary)
-    "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{dictionary.associated_annotation_project}&term_search_controller_query%5Bprojects%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10"
+    base_url = "https://pubannotation.org/term_search"
+    query_params = {
+      "term_search_controller_query[block_type]" => 'sentence',
+      "term_search_controller_query[terms]" => entry.identifier,
+      "term_search_controller_query[predicates]" => '',
+      "term_search_controller_query[projects]" => '',
+      "term_search_controller_query[base_project]" => dictionary.associated_annotation_project,
+      "term_search_controller_query[page]" => 1,
+      "term_search_controller_query[per]" => 10,
+    }
+
+    "#{base_url}?#{query_params.to_query}"
   end
 end

--- a/app/helpers/entries_helper.rb
+++ b/app/helpers/entries_helper.rb
@@ -1,5 +1,9 @@
 module EntriesHelper
   def is_url?(id)
-  	id =~ /^https?:/
+    id =~ /^https?:/
+  end
+
+  def pub_annotation_search_url(entry, dictionary)
+    "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{dictionary.associated_annotation_project}&term_search_controller_query%5Bprojects%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10"
   end
 end

--- a/app/helpers/entries_helper.rb
+++ b/app/helpers/entries_helper.rb
@@ -6,15 +6,15 @@ module EntriesHelper
   def pub_annotation_search_url(entry, dictionary)
     base_url = "https://pubannotation.org/term_search"
     query_params = {
-      "term_search_controller_query[block_type]" => 'sentence',
-      "term_search_controller_query[terms]" => entry.identifier,
-      "term_search_controller_query[predicates]" => '',
-      "term_search_controller_query[projects]" => '',
-      "term_search_controller_query[base_project]" => dictionary.associated_annotation_project,
-      "term_search_controller_query[page]" => 1,
-      "term_search_controller_query[per]" => 10,
+      block_type: 'sentence',
+      terms: entry.identifier,
+      predicates: '',
+      projects: '',
+      base_project: dictionary.associated_annotation_project,
+      page: 1,
+      per: 10,
     }
 
-    "#{base_url}?#{query_params.to_query}"
+    "#{base_url}?#{query_params.to_query(:term_search_controller_query)}"
   end
 end

--- a/app/views/entries/_colgroup.erb
+++ b/app/views/entries/_colgroup.erb
@@ -2,9 +2,7 @@
     <col class="col_label">
     <col class="col_identifier">
     <col class="col_button">
-    <col class="col_button">
     <col class="col_tags">
-    <col class="col_button">
     <col class="col_button">
     <% if type_entries == 'Auto expanded' %>
       <col class="col_score">

--- a/app/views/entries/_colgroup.erb
+++ b/app/views/entries/_colgroup.erb
@@ -2,7 +2,9 @@
     <col class="col_label">
     <col class="col_identifier">
     <col class="col_button">
+    <col class="col_button">
     <col class="col_tags">
+    <col class="col_button">
     <col class="col_button">
     <% if type_entries == 'Auto expanded' %>
       <col class="col_score">

--- a/app/views/entries/_colgroup.erb
+++ b/app/views/entries/_colgroup.erb
@@ -1,7 +1,7 @@
   <colgroup>
     <col class="col_label">
     <col class="col_identifier">
-    <col class="col_button">
+    <col class="col_double_button">
     <col class="col_tags">
     <col class="col_button">
     <% if type_entries == 'Auto expanded' %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -29,6 +29,7 @@
     <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
   </td>
   <td style="border-left-style: none">
+    <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.assosiated_annatation_project}&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
   </td>
   <td style="border-right-style: none">
     <% entry.tags.each do |tag| %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -26,8 +26,10 @@
     -%>
   </td>
   <td style="border-left-style: none">
-    <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
-    <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
+    <div class="buttons-container">
+      <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
+      <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
+    </div>
   </td>
   <td style="border-right-style: none">
     <% entry.tags.each do |tag| %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -28,7 +28,7 @@
   <td style="border-left-style: none">
     <div class="buttons-container">
       <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
-      <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bprojects%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
+      <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, pub_annotation_search_url(entry, @dictionary), title: 'search') -%>
     </div>
   </td>
   <td style="border-right-style: none">

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -28,7 +28,7 @@
   <td style="border-left-style: none">
     <div class="buttons-container">
       <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
-      <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
+      <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
     </div>
   </td>
   <td style="border-right-style: none">

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -27,8 +27,6 @@
   </td>
   <td style="border-left-style: none">
     <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
-  </td>
-  <td style="border-left-style: none">
     <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
   </td>
   <td style="border-right-style: none">
@@ -36,7 +34,7 @@
       <%= tag.value %>
     <% end %>
   </td>
-  <td colspan="2" style="border-left-style: none"></td>
+  <td style="border-left-style: none"></td>
   <% if @type_entries == 'Auto expanded' %>
     <td style="border-right-style: none">
       <%= entry.score %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -28,7 +28,7 @@
   <td style="border-left-style: none">
     <div class="buttons-container">
       <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
-      <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
+      <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bprojects%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
     </div>
   </td>
   <td style="border-right-style: none">

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -29,7 +29,7 @@
     <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
   </td>
   <td style="border-left-style: none">
-    <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.assosiated_annatation_project}&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
+    <%= link_to('<i class="fa-solid fa-link"></i>'.html_safe, "https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=#{entry.identifier}&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=#{@dictionary.associated_annotation_project}&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10", title: 'search') -%>
   </td>
   <td style="border-right-style: none">
     <% entry.tags.each do |tag| %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -28,12 +28,14 @@
   <td style="border-left-style: none">
     <%= link_to('<i class="fa fa-search" aria-hidden="true"></i>'.html_safe, dictionary_path(@dictionary, id_search:entry.identifier), title: 'search') -%>
   </td>
+  <td style="border-left-style: none">
+  </td>
   <td style="border-right-style: none">
     <% entry.tags.each do |tag| %>
       <%= tag.value %>
     <% end %>
   </td>
-  <td style="border-left-style: none"></td>
+  <td colspan="2" style="border-left-style: none"></td>
   <% if @type_entries == 'Auto expanded' %>
     <td style="border-right-style: none">
       <%= entry.score %>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -37,14 +37,14 @@
           <%= submit_tag 'Search', class: 'button' -%>
         <% end -%>
       </th>
-      <th colspan="3">
+      <th colspan="2">
         Id
         <%= form_tag '', method: :get, :style=>'display:inline-block' do -%>
           <%= text_field_tag :id_search, params[:id_search], required: true -%>
           <%= submit_tag 'Search', class: 'button' -%>
         <% end -%>
       </th>
-      <th colspan="3">
+      <th colspan="2">
           <%= form_tag '', method: :get, class: 'tag-search-container' do -%>
             Tags
             <%= select_tag :tag_search,
@@ -77,7 +77,7 @@
       <%= render partial: "entries/entry", collection: @entries -%>
 
       <tr>
-        <td colspan="7" style="border-style:none"></td>
+        <td colspan="5" style="border-style:none"></td>
         <% if ['Gray', 'Active'].include?(@type_entries) %>
           <td style="text-align:center">
             <a title="switch selected entries to black" href="javascript:{}" onclick="document.getElementById('switch_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>

--- a/app/views/entries/_table.html.erb
+++ b/app/views/entries/_table.html.erb
@@ -37,14 +37,14 @@
           <%= submit_tag 'Search', class: 'button' -%>
         <% end -%>
       </th>
-      <th colspan="2">
+      <th colspan="3">
         Id
         <%= form_tag '', method: :get, :style=>'display:inline-block' do -%>
           <%= text_field_tag :id_search, params[:id_search], required: true -%>
           <%= submit_tag 'Search', class: 'button' -%>
         <% end -%>
       </th>
-      <th colspan="2">
+      <th colspan="3">
           <%= form_tag '', method: :get, class: 'tag-search-container' do -%>
             Tags
             <%= select_tag :tag_search,
@@ -77,7 +77,7 @@
       <%= render partial: "entries/entry", collection: @entries -%>
 
       <tr>
-        <td colspan="5" style="border-style:none"></td>
+        <td colspan="7" style="border-style:none"></td>
         <% if ['Gray', 'Active'].include?(@type_entries) %>
           <td style="text-align:center">
             <a title="switch selected entries to black" href="javascript:{}" onclick="document.getElementById('switch_entries_form').submit(); return false;"><i class="fa fa-minus-square" aria-hidden="true"></i></a>


### PR DESCRIPTION
close #108 
Entry一覧へのPubAnnotationリンク追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- 虫眼鏡の列の右にリンクアイコンを設置し、issueで提示いただいたリンクに遷移するように設定

## 特記事項
- リンクにマウスを乗せたときに出てくる文言(title)は虫眼鏡と同じ`search`としています
- base projectの欄に紐づけたproject名が入るはずでしょうか？idはフォームに入力された状態ですが、project名は入力されていない状態で表示されました。（下の画像参照）

## 実行結果
### 画面
リンクを追加したDictionary詳細画面
<img width="1020" alt="image" src="https://github.com/pubannotation/pubdictionaries/assets/149556430/8b114400-22aa-492b-8d26-1ea447943af3">

リンク押下後
- 404ではなく、既存のページ？に飛びました
- base projectの欄に紐づけたproject名が入るはずでしょうか？
<img width="1026" alt="image" src="https://github.com/pubannotation/pubdictionaries/assets/149556430/768ded8b-ff6f-4225-8305-46534ee00560">

### リンク
`#{entry.identifier}`のところに`bbbbb`、
`#{@dictionary.associated_annotation_project}`のところにこのDictionary
と紐づけた`aaaa_project`
が入っていることを確認
```
# 実際のリンク
https://pubannotation.org/term_search?term_search_controller_query%5Bblock_type%5D=sentence&term_search_controller_query%5Bterms%5D=bbbbb&term_search_controller_query%5Bpredicates%5D=&term_search_controller_query%5Bbase_project%5D=aaaa_project&term_search_controller_query%5Bbase_project%5D=&term_search_controller_query%5Bpage%5D=1&term_search_controller_query%5Bper%5D=10
```
