### PR TITLE
htmlに合わせたjsonデータ作成

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -29,8 +29,9 @@ class DictionariesController < ApplicationController
 		dics = Dictionary.index_dictionaries
 		respond_to do |format|
 			format.html # index.html.erb
-			format.json {
-				render json: dics.as_json(only: [:name, :entries_num], methods: [:maintainer, :dic_created_at]) }
+			format.json do
+				render json: dics.as_json(only: [:name, :entries_num], methods: [:maintainer, :dic_created_at])
+			end
 		end
 	end
 

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -26,19 +26,9 @@ class DictionariesController < ApplicationController
 			:per_page => 20
 		)
 
-		dictionaries = Dictionary.where(public: true).order(created_at: :desc)
-		dics = dictionaries.map do |dic|
-			{
-				name: dic.name,
-				entries_num: dic.entries_num,
-				user: dic.user.username,
-				created_at: dic.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
-			}
-		end
-
 		respond_to do |format|
 			format.html # index.html.erb
-			format.json { render json: dics }
+			format.json { render json: Dictionary.index_dictionaries_as_json }
 		end
 	end
 

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -26,9 +26,12 @@ class DictionariesController < ApplicationController
 			:per_page => 20
 		)
 
+		dics_as_json = Dictionary.index_dictionaries
+										.as_json(only: [:name, :entries_num], methods: [:maintainer, :dic_created_at])
+
 		respond_to do |format|
 			format.html # index.html.erb
-			format.json { render json: Dictionary.index_dictionaries_as_json }
+			format.json { render json: dics_as_json }
 		end
 	end
 

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -26,6 +26,16 @@ class DictionariesController < ApplicationController
 			:per_page => 20
 		)
 
+		dictionaries = Dictionary.where(public: true).order(created_at: :desc)
+		dics = dictionaries.map do |dic|
+			{
+				name: dic.name,
+				entries_num: dic.entries_num,
+				user: dic.user.username,
+				created_at: dic.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+			}
+		end
+
 		respond_to do |format|
 			format.html # index.html.erb
 			format.json { render json: dics }

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -26,12 +26,11 @@ class DictionariesController < ApplicationController
 			:per_page => 20
 		)
 
-		dics_as_json = Dictionary.index_dictionaries
-										.as_json(only: [:name, :entries_num], methods: [:maintainer, :dic_created_at])
-
+		dics = Dictionary.index_dictionaries
 		respond_to do |format|
 			format.html # index.html.erb
-			format.json { render json: dics_as_json }
+			format.json {
+				render json: dics.as_json(only: [:name, :entries_num], methods: [:maintainer, :dic_created_at]) }
 		end
 	end
 

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -83,6 +83,8 @@ class Dictionary < ApplicationRecord
 		end
 	}
 
+	scope :index_dictionaries, -> { where(public: true).order(created_at: :desc) }
+
 	class << self
 		def find_dictionaries_from_params(params)
 			dic_names = if params.has_key?(:dictionaries)
@@ -140,11 +142,6 @@ class Dictionary < ApplicationRecord
 				h[entry.identifier] << {label: entry.label, dictionary: entry.dictionary.name}
 				h
 			end
-		end
-
-		def index_dictionaries_as_json
-			where(public: true).order(created_at: :desc)
-			.as_json(only: [:name, :entries_num], methods: [:maintainer, :dic_created_at])
 		end
 	end
 

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -141,6 +141,11 @@ class Dictionary < ApplicationRecord
 				h
 			end
 		end
+
+		def index_dictionaries_as_json
+			where(public: true).order(created_at: :desc)
+			.as_json(only: [:name, :entries_num], methods: [:maintainer, :dic_created_at])
+		end
 	end
 
 	# Override the original to_param so that it returns name, not ID, for constructing URLs.
@@ -612,5 +617,13 @@ class Dictionary < ApplicationRecord
       end
       update_entries_num
     end
+  end
+
+  def maintainer
+    self.user.username
+  end
+
+  def dic_created_at
+    self.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
   end
 end


### PR DESCRIPTION
close #109 
htmlに合わせたjsonデータ作成が完了しましたので、ご確認よろしくお願いいたします。

## 確認したこと
1. 過去のcommitの段階で同じエラー(#109 )が起きているか確認　→　起きていた
2. `dics`の部分を`Dictionary.all`にしてみる
  　→　indexのhtmlでは`public: :true`のみで表示される内容も絞られているので、不適当と判断

## 修正に採用したこと
- htmlで表示している条件(`@dictionaries_grid`)と同じDictionaryを抜粋
- それらのnameなど、htmlで表示している項目をマッピングしたJson用データを作成し、`dics`としてjsonに渡す

## 実行結果
上：JSON、下：HTML
<img width="1020" alt="image" src="https://github.com/pubannotation/pubdictionaries/assets/149556430/f9a6a70b-d1bc-4526-811d-09071a17d62b">

