### PR TITLE
dictionary名を変更したらエラーになる件の原因究明と対処

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -228,12 +228,7 @@ class DictionariesController < ApplicationController
 
 			db_loc_old = @dictionary.sim_string_db_dir
 			if @dictionary.update(dictionary_params)
-				db_loc_new = @dictionary.sim_string_db_dir
-				if Dir.exist?(db_loc_old)
-					FileUtils.mv db_loc_old, db_loc_new unless db_loc_new == db_loc_old
-				else
-					FileUtils.mkdir_p(db_loc_new)
-				end
+				@dictionary.update_db_location(db_loc_old)
 				if @dictionary.update_tags(tag_list)
 					redirect_to @dictionary
 				else

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -229,7 +229,11 @@ class DictionariesController < ApplicationController
 			db_loc_old = @dictionary.sim_string_db_dir
 			if @dictionary.update(dictionary_params)
 				db_loc_new = @dictionary.sim_string_db_dir
-				FileUtils.mv db_loc_old, db_loc_new unless db_loc_new == db_loc_old
+				if Dir.exist?(db_loc_old)
+					FileUtils.mv db_loc_old, db_loc_new unless db_loc_new == db_loc_old
+				else
+					FileUtils.mkdir_p(db_loc_new)
+				end
 				if @dictionary.update_tags(tag_list)
 					redirect_to @dictionary
 				else

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -397,6 +397,15 @@ class Dictionary < ApplicationRecord
 		Dictionary::SIM_STRING_DB_DIR + self.name
 	end
 
+	def update_db_location(db_loc_old)
+		db_loc_new = self.sim_string_db_dir
+		if Dir.exist?(db_loc_old)
+			FileUtils.mv db_loc_old, db_loc_new unless db_loc_new == db_loc_old
+		else
+			FileUtils.mkdir_p(db_loc_new)
+		end
+	end
+
 	def downloadable_zip_path
 		@downloadable_path ||= DOWNLOADABLES_DIR + filename + '.zip'
 	end


### PR DESCRIPTION
close #113 
dictionary名を変更したらエラーになる件の対処をしましたので、ご確認よろしくお願いいたします。

## 原因
デバッグの結果、そのDictionaryに事前に`@dictionary.sim_string_db_dir`が設定されていないことが原因で、以下の流れでエラーになっていました。

```
def update
  begin
...
    db_loc_old = @dictionary.sim_string_db_dir
    if @dictionary.update(dictionary_params)
      db_loc_new = @dictionary.sim_string_db_dir
      FileUtils.mv db_loc_old, db_loc_new unless db_loc_new == db_loc_old
...
  rescue => e
    redirect_back fallback_location: @dictionary, notice: e.message
  end
end
```

- `Dictionary.name`を変更してDictionary#updateを実行
- `@dictionary.update(dictionary_params)`が成功
- `db_loc_old`が存在しないため、`FileUtils.mv`がエラー
- `resucue→redirect_back`しようとするが、redirect_backしようとしているupdate前のアドレスがない（Dictionary名はすでにupdateした後のため)と判断してエラー


## 実施したこと
- `FileUtils.mv db_loc_old, db_loc_new`の実行条件として、`db_loc_old`が存在するかの事前確認を追加
- `db_loc_old`が存在しない場合に`FileUtils.mv`ではなく`mkdir_p(db_loc_new)`で新規作成するように追記

## 実行結果

https://github.com/pubannotation/pubdictionaries/assets/149556430/536b6404-7301-48c1-9755-684504bf16a9

