### PR TITLE
seedにassociated_annotation_project追加

### DIFF
--- a/app/views/dictionaries/_form.html.erb
+++ b/app/views/dictionaries/_form.html.erb
@@ -64,7 +64,7 @@
     </tr>
 
     <tr>
-      <th style="width: 6em;"><%= f.label :associated_annotation_project, "Associated Annotation Project" %></th>
+      <th style="width: 6em;"><%= f.label :associated_annotation_project, "Associated Annotation Project*" %></th>
       <td>
         <p class="note" style="margin-top:0">Please specify PubAnnotation's project linked to this dictionary if you have.</p>
         <%= f.text_field :associated_annotation_project, required: true, style: "box-sizing: border-box; width:15em" %></td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,7 @@ ActiveRecord::Base.transaction do
   dictionary = user.dictionaries.find_or_create_by(name: 'EntrezGene') do |dictionary|
     dictionary.description = 'EntrezGene dictionary'
     dictionary.public = true
+    dictionary.associated_annotation_project = 'aaa_project'
   end
 
   # add tags to dictionary


### PR DESCRIPTION
close #120
seedにassociated_annotation_project追加が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
- formにassociated_annotation_projectの項目を追加した際、必須の`*`を記載し忘れていたため、追記
- seedファイルにてDictionaryを作成する箇所にassociated_annotation_projectの設定を追加

## 実行結果
問題なくseed実行ができたことを確認
<img width="595" alt="image" src="https://github.com/pubannotation/pubdictionaries/assets/149556430/3eb2b919-2140-4924-82d9-db394754ffbc">
