### PR TITLE
google reCAPTCHAの登録手順をREADMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,41 @@ cp .env.example .env
 CLIENT_ID=[Generated client id]
 CLIENT_SECRET=[Generated client secret]
 ```
+
+### ReCAPTCHA settings procedure
+
+Access the Google reCAPTCHA site and log in with your Google account.
+```
+https://www.google.com/recaptcha/admin/create
+```
+
+The first screen that opens is the paid Enterprise version.  
+Click "Switch to create a legacy key" to switch to the free version.
+```
+Switch to create a legacy key
+```
+
+Enter the required information.
+
+label:
+```
+pubdictionaries
+```
+
+reCAPTCHA type:
+```
+v2 "I'm not a robot" checkbox
+```
+
+domain:  
+Add your domain, example:
+```
+example.com
+```
+
+After you register your site, site_key and secret_key are generated.  
+Add keys to .env file to use reCAPTCHA on your app.
+```
+RECAPTCHA_SITE_KEY=[Generated site key]
+RECAPTCHA_SECRET_KEY=[Generated secret key]
+```


### PR DESCRIPTION
## 概要
google reCAPTCHAの登録手順をREADMEに追記しました。

内容はPubAnnotationに書いたものとほぼ同じです。
一点だけ変更を加えており、labelの例を`pubannotation`から`pubdictionaries`と、リポジトリに合わせる形にしました。
|<img width="379" alt="image" src="https://github.com/user-attachments/assets/7383abf4-a2c8-4bdc-a5c5-97599530eff2">|
|:-|
