### PR TITLE
アノテーションが終わるとコールバックURLに結果をPOSTする機構を追加

### DIFF
--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -1,5 +1,5 @@
 class AnnotationController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:annotation_task]
+  skip_before_action :verify_authenticity_token, only: [:annotation_request, :annotation_task]
 
   # GET / POST
   def text_annotation
@@ -141,7 +141,6 @@ class AnnotationController < ApplicationController
 
     # job = TextAnnotationJob.new(target, dictionaries, options)
     # job.perform()
-
     active_job = TextAnnotationJob.perform_later(target, dictionaries, options, callback_url)
     active_job.create_job_record("Text annotation", num_items, time_for_annotation)
   end

--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -39,7 +39,8 @@ class AnnotationController < ApplicationController
     raise TextAnnotator::AnnotationQueueOverflowError unless Job.number_of_tasks_to_go(:annotation) < 8
 
     time_for_annotation = calc_time_for_annotation(targets)
-    job = enqueue_job(targets, targets.length, time_for_annotation)
+    callback_url = params[:callback_url]
+    job = enqueue_job(targets, targets.length, time_for_annotation, callback_url)
 
     respond_to do |format|
       format.any {head :ok}
@@ -134,14 +135,14 @@ class AnnotationController < ApplicationController
     r
   end
 
-  def enqueue_job(target, num_items, time_for_annotation)
+  def enqueue_job(target, num_items, time_for_annotation, callback_url = nil)
     dictionaries = Dictionary.find_dictionaries_from_params(params)
     options = get_options_from_params
 
     # job = TextAnnotationJob.new(target, dictionaries, options)
     # job.perform()
 
-    active_job = TextAnnotationJob.perform_later(target, dictionaries, options)
+    active_job = TextAnnotationJob.perform_later(target, dictionaries, options, callback_url)
     active_job.create_job_record("Text annotation", num_items, time_for_annotation)
   end
 

--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -40,10 +40,9 @@ class AnnotationController < ApplicationController
 
     time_for_annotation = calc_time_for_annotation(targets)
     job = enqueue_job(targets, targets.length, time_for_annotation)
-    result_name = TextAnnotator::BatchResult.new(nil, job.id).filename
 
     respond_to do |format|
-      format.any {head :see_other, location: annotation_result_url(result_name), retry_after: time_for_annotation}
+      format.any {head :ok}
     end
   rescue ArgumentError => e
     respond_to do |format|

--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -1,7 +1,7 @@
 class TextAnnotationJob < ApplicationJob
   queue_as :annotation
 
-  def perform(target, dictionaries, options)
+  def perform(target, dictionaries, options, callback_url = nil)
     single_target = false
     targets = if target.class == Array
       target
@@ -59,6 +59,10 @@ class TextAnnotationJob < ApplicationJob
         end
       end
       TextAnnotator::BatchResult.new(nil, @job.id).save!(annotation_result)
+    end
+
+    if callback_url
+      Net::HTTP.post(URI.parse(callback_url), annotation_result.to_json, {'Content-type' => 'application/json'})
     end
   end
 

--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -1,7 +1,7 @@
 class TextAnnotationJob < ApplicationJob
   queue_as :annotation
 
-  def perform(target, dictionaries, options, callback_url = nil)
+  def perform(target, dictionaries, options, callback_url)
     single_target = false
     targets = if target.class == Array
       target
@@ -61,6 +61,7 @@ class TextAnnotationJob < ApplicationJob
       TextAnnotator::BatchResult.new(nil, @job.id).save!(annotation_result)
     end
 
+    binding.break
     if callback_url
       Net::HTTP.post(URI.parse(callback_url), annotation_result.to_json, {'Content-type' => 'application/json'})
     end


### PR DESCRIPTION
Closes: #131

## 概要
PubAnnotationのアノテーション獲得プロトコールの改善における、PubDictionaries側の処理を追加しました。

## 実装内容
- annotation_controller#annotation_request
  - パラメータからコールバックURLを取得し、TextAnnotationJobにコールバックURLを渡すように変更
  - アクション自体のHTTP返答は303 see otherから200 okに変更
  - ログに`Can't verify CSRF token authenticity.`が出ていたので、annotation_taskアクションと同様にCSRFチェックを無効化
- TextAnnotationJob
  - コールバックURLがある場合はそのURLにアノテーション結果をPOSTする処理を追加

## 動作確認
### アノテーション結果の確認
#### annotation_task→process_tasks_queue
従来のアノテーション結果です
![image](https://github.com/user-attachments/assets/ffb05ef6-5685-4972-8ac4-2e3e6bd0eb43)
![image](https://github.com/user-attachments/assets/8512295e-4f89-4ab1-8715-0b3e941c2325)

#### annotation_request→annotation_reception#create
callbackURLへPOSTしたアノテーション結果です。従来のものと一致していることが確認できます。
![image](https://github.com/user-attachments/assets/c400d733-feb2-4370-b3da-8bb727db6fe4)