### PR TITLE
コールバックURLへのリクエスト修正

### DIFF
--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -97,6 +97,8 @@ class TextAnnotationJob < ApplicationJob
     url = URI.parse(callback_url)
     http = Net::HTTP.new(url.host, url.port)
     request = Net::HTTP::Put.new(url.path, {'Content-type' => 'application/json'})
+    http.use_ssl = true if url.scheme == 'https'
+
     result = (annotation_result.class == Array) ? annotation_result : [annotation_result]
     request.body = result.to_json
 

--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -62,7 +62,12 @@ class TextAnnotationJob < ApplicationJob
     end
 
     if callback_url
-      Net::HTTP.post(URI.parse(callback_url), annotation_result.to_json, {'Content-type' => 'application/json'})
+      url = URI.parse(callback_url)
+      http = Net::HTTP.new(url.host, url.port)
+      request = Net::HTTP::Put.new(url.path, {'Content-type' => 'application/json'})
+      request.body = annotation_result.to_json
+
+      http.request(request)
     end
   end
 

--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -62,13 +62,7 @@ class TextAnnotationJob < ApplicationJob
     end
 
     if callback_url
-      url = URI.parse(callback_url)
-      http = Net::HTTP.new(url.host, url.port)
-      request = Net::HTTP::Put.new(url.path, {'Content-type' => 'application/json'})
-      result = (annotation_result.class == Array) ? annotation_result : [annotation_result]
-      request.body = result.to_json
-
-      http.request(request)
+      http_put(callback_url, annotation_result)
     end
   end
 
@@ -97,5 +91,15 @@ class TextAnnotationJob < ApplicationJob
   def clean_files
     to_delete = TextAnnotator::BatchResult.older_files 1.day
     File.delete(*to_delete)
+  end
+
+  def http_put(callback_url, annotation_result)
+    url = URI.parse(callback_url)
+    http = Net::HTTP.new(url.host, url.port)
+    request = Net::HTTP::Put.new(url.path, {'Content-type' => 'application/json'})
+    result = (annotation_result.class == Array) ? annotation_result : [annotation_result]
+    request.body = result.to_json
+
+    http.request(request)
   end
 end

--- a/app/jobs/text_annotation_job.rb
+++ b/app/jobs/text_annotation_job.rb
@@ -65,7 +65,8 @@ class TextAnnotationJob < ApplicationJob
       url = URI.parse(callback_url)
       http = Net::HTTP.new(url.host, url.port)
       request = Net::HTTP::Put.new(url.path, {'Content-type' => 'application/json'})
-      request.body = annotation_result.to_json
+      result = (annotation_result.class == Array) ? annotation_result : [annotation_result]
+      request.body = result.to_json
 
       http.request(request)
     end


### PR DESCRIPTION
## 概要
コールバックURLへのリクエストをPOSTからPUTに変更しました。

## 実装内容
- コールバックURLへのリクエストをPOSTからPUTに変更
- アノテーション結果は必ず配列として返すように変更

## 動作確認
PUTリクエストの確認と結果が配列になっていることを確認しました。

PubAnnotation側
![image](https://github.com/user-attachments/assets/76d14a9c-90f2-4604-ace2-2b0139c0dd16)