### PR TITLE
Recaptcha環境変数を設定していない場合に機能を無効化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery
 
-  helper_method :recaptcha_usable?
-
-  def recaptcha_usable?
-    ENV['RECAPTCHA_SITE_KEY'].present? && ENV['RECAPTCHA_SECRET_KEY'].present?
-  end
-
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,12 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery
 
+  helper_method :recaptcha_usable?
+
+  def recaptcha_usable?
+    ENV['RECAPTCHA_SITE_KEY'].present? && ENV['RECAPTCHA_SECRET_KEY'].present?
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/concerns/recaptchable.rb
+++ b/app/controllers/concerns/recaptchable.rb
@@ -1,0 +1,11 @@
+module Recaptchable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :recaptcha_usable?
+  end
+
+  def recaptcha_usable?
+    ENV['RECAPTCHA_SITE_KEY'].present? && ENV['RECAPTCHA_SECRET_KEY'].present?
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -4,6 +4,7 @@ class Users::PasswordsController < Devise::PasswordsController
   private
 
   def validate_recaptcha
+    return unless recaptcha_usable?
     self.resource = resource_class.new
 
     unless verify_recaptcha(model: resource)

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,10 +1,11 @@
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :validate_recaptcha, only: [:create]
+  include Recaptchable
+
+  before_action :validate_recaptcha, only: [:create], if: :recaptcha_usable?
 
   private
 
   def validate_recaptcha
-    return unless recaptcha_usable?
     self.resource = resource_class.new
 
     unless verify_recaptcha(model: resource)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   private
 
   def validate_recaptcha
+    return unless recaptcha_usable?
     self.resource = resource_class.new(sign_up_params)
     resource.validate # Without this, all validations will not be displayed.
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,10 +1,11 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :validate_recaptcha, only: [:create]
+  include Recaptchable
+
+  before_action :validate_recaptcha, only: [:create], if: :recaptcha_usable?
 
   private
 
   def validate_recaptcha
-    return unless recaptcha_usable?
     self.resource = resource_class.new(sign_up_params)
     resource.validate # Without this, all validations will not be displayed.
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,10 +11,12 @@
       <td><%= f.email_field :email, :autofocus => true, class: 'form-field' %></td>
     </tr>
 
-    <tr>
-      <th></th>
-      <td><%= recaptcha_tags %></td>
-    </tr>
+    <% if recaptcha_usable? %>
+      <tr>
+        <th></th>
+        <td><%= recaptcha_tags %></td>
+      </tr>
+    <% end %>
 
     <tr>
       <th colspan="2"><%= f.submit "Send me reset password instructions", class: :button %></th>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -26,10 +26,12 @@
 		  <td><%= f.password_field :password_confirmation, class: 'form-field' %></td>
 		</tr>
 
-		<tr>
-		  <th></th>
-		  <td><%= recaptcha_tags %></td>
-		</tr>
+		<% if recaptcha_usable? %>
+			<tr>
+				<th></th>
+				<td><%= recaptcha_tags %></td>
+			</tr>
+		<% end %>
 
 		<tr>
 			<th colspan="2"><%= f.submit "Sign up", class: :button %></th>


### PR DESCRIPTION
## 概要
Recaptcha環境変数を設定していない場合に機能を無効化しました。

## 実装内容
- recaptcha環境変数が設定されていない場合に、以下の機能を無効化
  - viewでの表示
  - controllerでの認証

## 動作確認
### 環境変数が設定されていない場合にrecaptchaが無効
#### `users/sign_up`
|<img width="463" alt="image" src="https://github.com/user-attachments/assets/256d50b5-9597-4f15-8b9e-429ba7d6a7ef">|
|:-|

リダイレクト
|<img width="1030" alt="image" src="https://github.com/user-attachments/assets/3ddfe69e-fec3-4aea-bc40-1431f8d00a3d">|
|:-|

#### `users/passwords/new`
|<img width="836" alt="image" src="https://github.com/user-attachments/assets/6b138cbc-bfbb-4104-b47d-560a6c9095c7">|
|:-|

リダイレクト
|<img width="699" alt="image" src="https://github.com/user-attachments/assets/38218b7a-4fbb-4ba4-8093-2e8eacfa3bcf">|
|:-|

### 再度環境変数を設定すると表示は戻る
|<img width="585" alt="image" src="https://github.com/user-attachments/assets/0a1511d6-ef82-4764-a660-0e7de39ad2a7">|
|:-|