### PR TITLE
辞書のエントリー操作・バルクアップロードAPIを作成

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -69,8 +69,8 @@ class Api::V1::EntriesController < ApplicationController
       return
     end
 
-      source_filepath = params[:file].tempfile.path
-      LoadEntriesFromFileJob.copy_file_and_perform(@dictionary, source_filepath)
+    source_filepath = params[:file].tempfile.path
+    LoadEntriesFromFileJob.copy_file_and_perform(@dictionary, source_filepath)
 
     render json: { message: "Upload dictionary entries task was successfully created." }, status: :accepted
   end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -23,15 +23,9 @@ class Api::V1::EntriesController < ApplicationController
     end
 
     begin
-      ActiveRecord::Base.transaction do
-        success, entry = @dictionary.create_entry(label, identifier, params[:tags])
+      entry = @dictionary.create_entry!(label, identifier, params[:tags])
 
-        if success
-          render json: { message: "The white entry #{entry} was created." }, status: :created
-        else
-          render json: { message: "The white entry #{entry} could not be created." }, status: :unprocessable_entity
-        end
-      end
+      render json: { message: "The white entry #{entry} was created." }, status: :created
     rescue => e
       render json: { error: e.message }, status: :internal_server_error
     end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::EntriesController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :create
+
   def create
     dictionary = Dictionary.editable(current_user).find_by(name: params[:dictionary_id])
 

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -78,7 +78,8 @@ class Api::V1::EntriesController < ApplicationController
     end
 
     begin
-      LoadEntriesFromFileJob.prepare_file_and_perform(@dictionary, params[:file])
+      source_filepath = params[:file].tempfile.path
+      LoadEntriesFromFileJob.copy_file_and_perform(@dictionary, source_filepath)
 
       render json: { message: "Upload dictionary entries task was successfully created." }, status: :accepted
     rescue => e

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -1,3 +1,47 @@
 class Api::V1::EntriesController < ApplicationController
-  def create; end
+  def create
+    dictionary = Dictionary.editable(current_user).find_by(name: params[:dictionary_id])
+
+    if dictionary.nil?
+      render json: { error: "Could not find the dictionary, #{params[:dictionary_id]}." }, status: :not_found
+      return
+    end
+
+    label = params[:label]&.strip
+    if label.blank?
+      render json: { error: "A label should be supplied." }, status: :bad_request
+      return
+    end
+
+    identifier = params[:identifier]&.strip
+    if identifier.blank?
+      render json: { error: "An identifier should be supplied." }, status: :bad_request
+      return
+    end
+
+    entry = dictionary.entries.find_by(label:, identifier:)
+    if entry.present?
+      render json: { error: "The entry #{entry} already exists in the dictionary." }, status: :conflict
+      return
+    end
+
+    begin
+      ActiveRecord::Base.transaction do
+        entry = dictionary.new_entry(label, identifier, nil, EntryMode::WHITE, true)
+
+        tag_ids = params[:tags] || []
+        entry.tag_ids = tag_ids
+
+        if entry.save
+          dictionary.update_entries_num
+
+          render json: { message: "The white entry #{entry} was created." }, status: :created
+        else
+          render json: { message: "The white entry #{entry} could not be created." }, status: :unprocessable_entity
+        end
+      end
+    rescue => e
+      render json: { error: e.message }, status: :internal_server_error
+    end
+  end
 end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -52,9 +52,16 @@ class Api::V1::EntriesController < ApplicationController
       return
     end
 
+    entries = Entry.where(id: params[:entry_id])
+
+    if entries.empty?
+      render json: { error: "Could not find the entries, #{params[:entry_id]}" }, status: :not_found
+      return
+    end
+
     begin
       ActiveRecord::Base.transaction do
-        Entry.where(id: params[:entry_id]).destroy_all
+        entries.destroy_all
         @dictionary.update_entries_num
       end
 

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -98,12 +98,7 @@ class Api::V1::EntriesController < ApplicationController
         return
       end
 
-      source_filepath = params[:file].tempfile.path
-      target_filepath = File.join('tmp', "upload-#{@dictionary.name}-#{Time.now.to_s[0..18].gsub(/[ :]/, '-')}")
-      FileUtils.cp source_filepath, target_filepath
-
-      active_job = LoadEntriesFromFileJob.perform_later(@dictionary, target_filepath)
-      active_job.create_job_record("Upload dictionary entries")
+      LoadEntriesFromFileJob.prepare_file_and_perform(@dictionary, params[:file])
 
     rescue => e
       render json: { error: e.message }, status: :internal_server_error

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::EntriesController < ApplicationController
+  def create; end
+end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -96,7 +96,7 @@ class Api::V1::EntriesController < ApplicationController
       render json: { error: e.message }, status: :internal_server_error
     end
 
-    render json: { message: "Entry was successfully redid." }, status: :ok
+    render json: { message: "Entry was successfully undid." }, status: :ok
   end
 
   def destroy_entries

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -73,7 +73,7 @@ class Api::V1::EntriesController < ApplicationController
 
   def undo
     if @dictionary.nil?
-    render json: { error: "Cannot find the dictionary." }, status: :bad_request
+      render json: { error: "Cannot find the dictionary." }, status: :bad_request
       return
     end
 

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -29,14 +29,9 @@ class Api::V1::EntriesController < ApplicationController
 
     begin
       ActiveRecord::Base.transaction do
-        entry = dictionary.new_entry(label, identifier, nil, EntryMode::WHITE, true)
+        success, entry = dictionary.create_entry(label, identifier, params[:tags])
 
-        tag_ids = params[:tags] || []
-        entry.tag_ids = tag_ids
-
-        if entry.save
-          dictionary.update_entries_num
-
+        if success
           render json: { message: "The white entry #{entry} was created." }, status: :created
         else
           render json: { message: "The white entry #{entry} could not be created." }, status: :unprocessable_entity

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -97,8 +97,7 @@ class LoadEntriesFromFileJob < ApplicationJob
     end
   end
 
-  def self.prepare_file_and_perform(dictionary, uploaded_file)
-    source_filepath = uploaded_file.tempfile.path
+  def self.copy_file_and_perform(dictionary, source_filepath)
     target_filepath = File.join('tmp', "upload-#{dictionary.name}-#{Time.now.to_s[0..18].gsub(/[ :]/, '-')}")
     FileUtils.cp source_filepath, target_filepath
 

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -109,22 +109,8 @@ class LoadEntriesFromFileJob < ApplicationJob
   def perform(dictionary, filename, mode = nil)
     # file preprocessing
     # TODO: at the moment, it is hard-coded. It should be improved.
-    # `/usr/bin/dos2unix #{filename}`
-    # `/usr/bin/cut -f1-3 #{filename} | sort -u | sort -k3 -o #{filename}`
-
-    # ファイルを読み込み、Unix形式の改行に変換
-    content = File.read(filename).gsub(/\r\n?/, "\n")
-
-    # TSVデータを処理
-    entries = content.lines.map do |line|
-      next if line.strip.empty? || line.start_with?('#')
-
-      fields = line.split("\t").first(3) # 最初の3カラムを取得
-      fields if fields[0] && fields[0].length.between?(2, 127) && fields[1] && fields[1].length.between?(2, 255)
-    end.compact.uniq.sort_by { |fields| fields[2] || "" } # タグでソート
-
-    # 結果をファイルに書き戻す
-    File.write(filename, entries.map { |fields| fields.join("\t") }.join("\n"))
+    `/usr/bin/dos2unix #{filename}`
+    `/usr/bin/cut -f1-3 #{filename} | sort -u | sort -k3 -o #{filename}`
 
     num_entries = File.read(filename).each_line.count
     if @job

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -4,4 +4,6 @@ module Exceptions
       super(msg)
     end
   end
+
+  class DictionaryNotFoundError < StandardError; end
 end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -300,16 +300,14 @@ class Dictionary < ApplicationRecord
     raise ArgumentError, "The entry, [#{label}, #{identifier}], is rejected: #{e.message} #{e.backtrace.join("\n")}."
   end
 
-  def create_entry(label, identifier, tag_ids = [])
+  def create_entry!(label, identifier, tag_ids = [])
     entry = new_entry(label, identifier, nil, EntryMode::WHITE, true)
     entry.tag_ids = tag_ids
 
-    if entry.save
-      update_entries_num
-      [true, entry]
-    else
-      [false, entry]
-    end
+    entry.save!
+    update_entries_num
+
+    entry
   end
 
   def empty_entries(mode = nil)

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -300,6 +300,18 @@ class Dictionary < ApplicationRecord
     raise ArgumentError, "The entry, [#{label}, #{identifier}], is rejected: #{e.message} #{e.backtrace.join("\n")}."
   end
 
+  def create_entry(label, identifier, tag_ids = [])
+    entry = new_entry(label, identifier, nil, EntryMode::WHITE, true)
+    entry.tag_ids = tag_ids
+
+    if entry.save
+      update_entries_num
+      [true, entry]
+    else
+      [false, entry]
+    end
+  end
+
   def empty_entries(mode = nil)
     transaction do
       case mode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :api do
+    namespace :v1 do
+      resources :entries, only: :create
+    end
+  end
+
   resources :jobs, only: [:index, :show, :destroy]
   delete 'jobs', to: "jobs#destroy_all"
   delete 'annotation_jobs', to: "jobs#destroy_all_annotation_jobs"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,10 @@ Rails.application.routes.draw do
         collection do
           delete '/', to: 'entries#destroy_entries'
         end
+
+        member do
+          put 'undo', to: 'entries#undo'
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
       resources :entries, only: :create do
         collection do
           delete '/', to: 'entries#destroy_entries'
+          post 'tsv', to: 'entries#upload_tsv'
         end
 
         member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,11 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :entries, only: :create
+      resources :entries, only: :create do
+        collection do
+          delete '/', to: 'entries#destroy_entries'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes: #138

## 概要
以下の実装を行いました。
- 辞書のエントリーの追加、削除、元に戻し等の操作をAPIでできるようにする。
- POSTによる辞書のバルクアップロードをAPIでできるようにする。

## 実装内容
- 以下機能のAPIを作成
  - エントリー追加 Api::V1::EntriesController#create
  - エントリー削除 Api::V1::EntriesController#destroy_entries
  - エントリー元に戻し Api::V1::EntriesController#undo
  - 辞書のバルクアップロード Api::V1::EntriesController#upload_tsv
- 各ルーティングを設定

## 動作確認
認証実装前の動作確認のために、全てのAPIに `current_user = User.first`を定義して行います。
この辞書の状態から動作確認します。
|<img width="1069" alt="image" src="https://github.com/user-attachments/assets/67d35532-f623-48d0-89bb-89e00efdcc8b">|
|:-|
### エントリーの追加
```
curl -X POST http://localhost:3001/api/v1/entries \
  -H "Content-Type: application/json" \
  -d '{
        "dictionary_id": "EntrezGene",
        "label": "test-with-api-call",
        "identifier": "1"
      }'
{"message":"The white entry ('test-with-api-call', '1') was created."}%
```

|<img width="1037" alt="image" src="https://github.com/user-attachments/assets/b7c81a5e-e959-4134-a965-0d28808bbd7e">|
|:-|

![image](https://github.com/user-attachments/assets/9cc5030d-7876-4ec1-b923-164c6c548cd9)

### エントリーの削除
先ほど追加したエントリーを削除します。
```
curl -X DELETE http://localhost:3001/api/v1/entries \
  -H "Content-Type: application/json" \
  -d '{
        "dictionary_id": "EntrezGene",
        "entry_id": 15
      }'
{"message":"Entry was successfully deleted."}%
```
|<img width="1033" alt="image" src="https://github.com/user-attachments/assets/067a5d07-6761-4296-951a-54a57117e624">|
|:-|

![image](https://github.com/user-attachments/assets/a5cd7a47-fb78-4790-8425-ac2cbe258b7f)

### エントリーの元に戻し
Black Mode Entryに対してundoを行い、Grayになることを検証します。
|<img width="1039" alt="image" src="https://github.com/user-attachments/assets/e688e837-4c1a-4f57-80f5-ffd34a3e2f0f">|
|:-|
```
curl -X PUT http://localhost:3001/api/v1/entries/8/undo \
  -H "Content-Type: application/json" \
  -d '{
        "dictionary_id": "EntrezGene"
      }'
{"message":"Entry was successfully undid."}%
```
gray entriesにBlack Mode Entryが追加されています。
|<img width="1036" alt="image" src="https://github.com/user-attachments/assets/1d5179e8-f173-499e-9a38-6567ff50e005">|
|:-|

![image](https://github.com/user-attachments/assets/d616f66a-ee32-42ec-81d3-638e6412f003)

### 辞書のバルクアップロード
テスト用のファイル
test.tsv
```
apple	APL001	fruit|food
banana	BAN123	fruit|yellow
pear	PEAR456

```

```
curl -X POST http://localhost:3001/api/v1/entries/tsv \
  -H "Content-Type: multipart/form-data" \
  -F "dictionary_id=EntrezGene" \
  -F "file=@test.tsv"
{"message":"Upload dictionary entries task was successfully created."}%
```

|<img width="1081" alt="image" src="https://github.com/user-attachments/assets/499707fb-2d76-4789-92fc-6ef8be680a9e">|
|:-|

![image](https://github.com/user-attachments/assets/76e3c946-9f97-4f1f-86b3-9c0d96f15cec)
