### PR TITLE
エントリー数更新をコールバックで行う形に変更

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -36,16 +36,12 @@ class Api::V1::EntriesController < ApplicationController
     end
 
     entries = Entry.where(id: params[:entry_id])
-
     if entries.empty?
       render json: { error: "Could not find the entries, #{params[:entry_id]}" }, status: :not_found
       return
     end
 
-    ActiveRecord::Base.transaction do
-      entries.destroy_all
-      @dictionary.update_entries_num
-    end
+    entries.destroy_all
 
     render json: { message: "Entry was successfully deleted." }, status: :ok
   end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -170,10 +170,7 @@ class EntriesController < ApplicationController
 
       raise ArgumentError, "No entry to be deleted is selected" unless params[:entry_id].present?
 
-      ActiveRecord::Base.transaction do
-        Entry.where(id: params[:entry_id]).destroy_all
-        dictionary.update_entries_num
-      end
+      Entry.where(id: params[:entry_id]).destroy_all
     rescue => e
       message = e.message
     end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -47,7 +47,6 @@ class EntriesController < ApplicationController
         entry.tag_ids = tag_ids
 
         message = if entry.save
-          dictionary.update_entries_num
           # dictionary.update_tmp_sim_string_db
           "The white entry #{entry} was created."
         else

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -303,9 +303,7 @@ class Dictionary < ApplicationRecord
   def create_entry!(label, identifier, tag_ids = [])
     entry = new_entry(label, identifier, nil, EntryMode::WHITE, true)
     entry.tag_ids = tag_ids
-
     entry.save!
-    update_entries_num
 
     entry
   end
@@ -710,7 +708,6 @@ class Dictionary < ApplicationRecord
           mode: EntryMode::AUTO_EXPANDED
         )
       end
-      update_entries_num
     end
   end
 

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -171,13 +171,13 @@ class Dictionary < ApplicationRecord
   end
 
   def undo_entry(entry)
-    transaction do
-      if entry.is_white?
-        entry.delete
-      elsif entry.is_black?
+    if entry.is_white?
+      entry.destroy
+    elsif entry.is_black?
+      transaction do
         entry.be_gray!
+        update_entries_num
       end
-      update_entries_num
     end
   end
 
@@ -325,7 +325,6 @@ class Dictionary < ApplicationRecord
       else
         raise ArgumentError, "Unexpected mode: #{mode}"
       end
-      update_entries_num
     end
   end
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -94,6 +94,7 @@ class Entry < ApplicationRecord
   }
 
   after_save :update_dictionary_entries_num
+  after_destroy :update_dictionary_entries_num
 
   def to_s
     "('#{label}', '#{identifier}')"

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -93,6 +93,8 @@ class Entry < ApplicationRecord
     where(mode: EntryMode::WHITE, dirty: true)
   }
 
+  after_save :update_dictionary_entries_num
+
   def to_s
     "('#{label}', '#{identifier}')"
   end
@@ -263,5 +265,9 @@ class Entry < ApplicationRecord
   def self.jaccard_sim(items1, items2)
     return 0.0 if items1.empty? || items2.empty?
     (items1 & items2).size.to_f / (items1 | items2).size
+  end
+
+  def update_dictionary_entries_num
+    dictionary.update_entries_num
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,7 +47,4 @@ ActiveRecord::Base.transaction do
 
     entry.tags = entry_def[:tags]
   end
-
-  # set entries_num
-  dictionary.update_entries_num
 end


### PR DESCRIPTION
Closes: #140 

## 概要
[issue](https://github.com/pubannotation/pubdictionaries/issues/140)に基づいてエントリー数更新をコールバックで行う形に変更しました。

## 実装内容
Entryモデルにエントリー数更新のコールバックを追加
コールバック追加により以下メソッドのエントリー更新処理を削除
  - after_save関連
    - EntriesController#create
    - api/v1/EntriesController#create
    - Dictionary#append_expanded_synonym_entries
    - seeds
  - after_destroy関連
    - EntriesController#destroy_entries
    - api/v1/EntriesController#destroy_entries
    - Dictionary#undo_entry
    - Dictionary#empty_entries

上記タイミングの他に、エントリーの色が変わるタイミングで`update_entries_num`を呼び出すことがあります。
Gray→Black, Black→Grayなどのタイミングでは`update_entries_num`を呼び出していて、Gray→Whiteのタイミングでは`update_entries_num`は呼び出していません。

after_updateを用いれば色変更のタイミングでも明示的に`update_entries_num`を書かずに更新できますが、Gray→Whiteのような不要なタイミングでも実行されるようになってしまうので実装しませんでした。

備考：`update_entries_num`メソッドはブラックエントリー以外の数をカウントしてentries_numカラムに代入しているので、一応Gray→Whiteのタイミングで実行してもエントリー数自体は正しく設定されます。
https://github.com/pubannotation/pubdictionaries/blob/114da0a79e9e6f77df26d279117458b74528b8f5/app/models/dictionary.rb#L192

エントリー色変更のタイミングでもエントリー数更新をすべきでしたらそのように変更しますのでコメントお願いします。

## 動作確認
### after_save時
#### EntriesController#create
|<img width="1052" alt="image" src="https://github.com/user-attachments/assets/700e9183-3a7c-4583-9f5f-8bf46da9c553">|
|:-|

ブラウザでエントリー追加後

|<img width="1033" alt="image" src="https://github.com/user-attachments/assets/11f90465-6383-4a0e-b12c-c0cff0a54cb0">|
|:-|

#### api/v1/EntriesController#create
|<img width="1033" alt="image" src="https://github.com/user-attachments/assets/1cae69f8-64a1-417a-9f8c-dd64b88b9b77">|
|:-|

APIで追加

|<img width="1037" alt="image" src="https://github.com/user-attachments/assets/6dd47692-2047-452f-80ba-f8399f840728">|
|:-|

#### Dictionary#append_expanded_synonym_entries
|<img width="1037" alt="image" src="https://github.com/user-attachments/assets/5efd90f5-d01d-4397-9d5c-b53d264229b5">|
|:-|

Automatically expand synonymsを実行

|<img width="1028" alt="image" src="https://github.com/user-attachments/assets/aee7bc7b-6bfb-46ab-9661-1f25e1cb59c8">|
|:-|

#### seeds
|<img width="1028" alt="image" src="https://github.com/user-attachments/assets/aee7bc7b-6bfb-46ab-9661-1f25e1cb59c8">|
|:-|

rails db:resetを実行

|<img width="1027" alt="image" src="https://github.com/user-attachments/assets/1b735f32-edc5-4a58-aa74-3f142594ed2c">|
|:-|

### after_destroy時
#### EntriesController#destroy_entries
このメソッドを呼び出す動線がGUIでは実装されてないようなので確認できませんでした。
同じように実装したapi/v1/EntriesController#destroy_entriesで動作が確認できているので問題ないとは思います。
https://github.com/pubannotation/pubdictionaries/blob/114da0a79e9e6f77df26d279117458b74528b8f5/app/views/entries/_table.html.erb#L83

#### api/v1/EntriesController#destroy_entries
|<img width="1022" alt="image" src="https://github.com/user-attachments/assets/52118fd7-0869-4362-96a2-7af997125198">|
|:-|

APIで削除

|<img width="1028" alt="image" src="https://github.com/user-attachments/assets/e227cd87-e11b-4a9b-b2d8-6062f9064327">|
|:-|

#### Dictionary#undo_entry
|<img width="1020" alt="image" src="https://github.com/user-attachments/assets/c951cae6-86ce-4d41-83ad-3a84880a4cf5">|
|:-|

Whiteエントリーをundo (削除される)

|<img width="1030" alt="image" src="https://github.com/user-attachments/assets/a154a034-ab58-41fb-8d04-52d27a11e09c">|
|:-|

#### Dictionary#empty_entries
|<img width="1026" alt="image" src="https://github.com/user-attachments/assets/ac4fd11e-2d7e-4e45-b87b-aa22425b230c">|
|:-|

該当メソッドを呼び出す操作を行う

|<img width="1019" alt="image" src="https://github.com/user-attachments/assets/bca33fcc-5fe9-4df1-8808-8a2d6d71f7f2">|
|:-|
