### PR TITLE
JobをAPIで削除する機能を追加

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -65,10 +65,15 @@ class Api::V1::EntriesController < ApplicationController
     end
 
     if @dictionary.jobs.count > 0
-      render json: {
-        error: "The last task is not yet dismissed. Please dismiss it and try again.",
-        task_dismiss_instruction: "To dismiss the task, send a DELETE request to /api/v1/jobs/#{@dictionary.jobs.last.id} ."
-      }, status: :bad_request
+      if @dictionary.jobs.last.running?
+        render json: { error: "The last task is still in progress. Please wait a moment and try again later." }, status: :conflict
+      else
+        render json: {
+          error: "The last task is not yet dismissed. Please dismiss it and try again.",
+          task_dismiss_instruction: "To dismiss the task, send a DELETE request to /api/v1/jobs/#{@dictionary.jobs.last.id} ."
+        }, status: :conflict
+      end
+
       return
     end
 

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -61,7 +61,10 @@ class Api::V1::EntriesController < ApplicationController
 
   def upload_tsv
     if @dictionary.jobs.count > 0
-      render json: { error: "The last task is not yet dismissed. Please dismiss it and try again." }, status: :bad_request
+      render json: {
+        error: "The last task is not yet dismissed. Please dismiss it and try again.",
+        task_dismiss_instruction: "To dismiss the task, send a DELETE request to /api/v1/jobs/#{@dictionary.jobs.last.id} ."
+      }, status: :bad_request
       return
     end
 
@@ -74,6 +77,7 @@ class Api::V1::EntriesController < ApplicationController
   private
 
   def set_dictionary
+    current_user = User.first
     @dictionary = Dictionary.editable(current_user).find_by(name: params[:dictionary_id])
     raise Exceptions::DictionaryNotFoundError if @dictionary.nil?
   end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -81,7 +81,6 @@ class Api::V1::EntriesController < ApplicationController
   private
 
   def set_dictionary
-    current_user = User.first
     @dictionary = Dictionary.editable(current_user).find_by(name: params[:dictionary_id])
     raise Exceptions::DictionaryNotFoundError if @dictionary.nil?
   end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -60,6 +60,10 @@ class Api::V1::EntriesController < ApplicationController
   end
 
   def upload_tsv
+    if @dictionary.jobs.any? && params[:replace_task] == 'true'
+      @dictionary.jobs.last.destroy_if_not_running
+    end
+
     if @dictionary.jobs.count > 0
       render json: {
         error: "The last task is not yet dismissed. Please dismiss it and try again.",

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::JobsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def destroy
+    job = Job.find(params[:id])
+
+    if job.running?
+      render json: { message: "Job #{params[:id]} is currently running and cannot be deleted." }, status: :unprocessable_entity
+      return
+    end
+
+    job.destroy_if_not_running
+    render json: { message: "Job #{params[:id]} was successfully deleted." }, status: :ok
+  rescue ActiveRecord::RecordNotFound => e
+    render json: { error: e.message }, status: :not_found
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,8 @@ Rails.application.routes.draw do
           put 'undo', to: 'entries#undo'
         end
       end
+
+      resources :jobs, only: :destroy
     end
   end
 


### PR DESCRIPTION
Closes: #143

## 概要
既存ジョブが残っているとジョブを作成するAPIが実行できない問題への対応として、
ジョブをAPIで削除する機能を追加しました。

コードレビューに加えて、以下の点についても確認をお願いしたいです。
- ジョブを消すAPIの案内メッセージなどの文言が問題ないか
- オプションはクエリパラメータで実装したが問題ないか
  - オプション名は問題ないか

## 実装内容
- ジョブ削除APIの追加
- ジョブがあるときにジョブを追加したらジョブのメッセージを返すとともに、消すAPIを案内するメッセージを添付
- ジョブ追加するAPIに、終了済みのジョブを強制的に消すオプションを追加

## 動作確認
### ジョブ削除API
```
curl -X DELETE http://localhost:3001/api/v1/jobs/4f196da6-d550-431c-9219-1d7d50891bba
{"message":"Job 4f196da6-d550-431c-9219-1d7d50891bba was successfully deleted."}%
```

ログ
![image](https://github.com/user-attachments/assets/5d4db723-f89b-45a1-b5ec-f97f292f73d4)

### ジョブのメッセージとAPI案内確認
ジョブがある状態でジョブを作成するAPIを実行
```
curl -X POST http://localhost:3001/api/v1/entries/tsv \
  -H "Content-Type: multipart/form-data" \
  -F "dictionary_id=EntrezGene" \
  -F "file=@test.tsv"
{"error":"The last task is not yet dismissed. Please dismiss it and try again.","task_dismiss_instruction":"To dismiss the task, send a DELETE request to /api/v1/jobs/4f196da6-d550-431c-9219-1d7d50891bba ."}%
```

### ジョブ削除オプション確認
既存ジョブが残っている状態でクエリパラメータ`replace_task=true`を添付して実行
```
curl -X POST "http://localhost:3001/api/v1/entries/tsv?replace_task=true" \
  -H "Content-Type: multipart/form-data" \
  -F "dictionary_id=EntrezGene" \
  -F "file=@test.tsv"
{"message":"Upload dictionary entries task was successfully created."}%
```

ログ
![image](https://github.com/user-attachments/assets/9af2078e-023c-46bd-98f2-4d97e06334b6)
