### PR TITLE
アクセストークンの寿命や関連を修正

### DIFF
--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -2,3 +2,13 @@
   box-sizing: border-box;
   width: 100%;
 }
+
+.disabled-button {
+  margin: 2px 0;
+  border: 2px outset #aaaaaa;
+  border-radius: 5px;
+  background: #EBEBEB;
+  font-family: Arial;
+  padding: 2px 6px 2px 6px;
+  text-decoration: none;
+}

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -2,7 +2,7 @@ class AccessTokensController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    current_user.create_access_token!(token: SecureRandom.hex(16))
+    current_user.create_access_token!
 
     redirect_back fallback_location: root_path, notice: "Access token was successfully created."
   end

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -2,7 +2,7 @@ class AccessTokensController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    current_user.create_access_token!
+    current_user.create_access_token!(token: SecureRandom.hex(16))
 
     redirect_back fallback_location: root_path, notice: "Access token was successfully created."
   end

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -2,9 +2,8 @@ class AccessTokensController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    token = current_user.create_access_token!
+    current_user.create_access_token!
 
-    redirect_back fallback_location: root_path,
-                  notice: "Access token was successfully created. It will expired in #{token.expired_at}."
+    redirect_back fallback_location: root_path, notice: "Access token was successfully created."
   end
 end

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -6,4 +6,10 @@ class AccessTokensController < ApplicationController
 
     redirect_back fallback_location: root_path, notice: "Access token was successfully created."
   end
+
+  def destroy
+    current_user.access_token.destroy
+
+    redirect_back fallback_location: root_path, notice: 'Access token was successfully deleted.'
+  end
 end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -87,7 +87,7 @@ class Api::V1::EntriesController < ApplicationController
   private
 
   def authenticate_token
-    if token&.live?
+    if token
       sign_in(token.user)
     else
       render_token_invalid_error

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,5 @@ class UsersController < ApplicationController
       :order_direction => 'desc',
       :per_page => 20
     )
-    @latest_access_token = @user.latest_access_token
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,3 +1,10 @@
 class AccessToken < ApplicationRecord
   belongs_to :user
+  before_create :set_token
+
+  private
+
+  def set_token
+    self.token = SecureRandom.hex(16)
+  end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,10 +1,10 @@
 class AccessToken < ApplicationRecord
   belongs_to :user
-  before_create :set_token
+  before_create :generate_token
 
   private
 
-  def set_token
+  def generate_token
     self.token = SecureRandom.hex(16)
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,7 +1,3 @@
 class AccessToken < ApplicationRecord
   belongs_to :user
-
-  def live?
-    expired_at > Time.current
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_many :dictionaries, dependent: :destroy
   has_many :associations
   has_many :associated_dictionaries, through: :associations, source: :dictionary
-  has_many :access_tokens, dependent: :destroy
+  has_one :access_token, dependent: :destroy
 
   validates :username, :presence => true, :length => {:minimum => 5, :maximum => 20}, uniqueness: true
   validates_format_of :username, :with => /\A[a-z0-9][ a-z0-9_-]+\z/i
@@ -29,13 +29,5 @@ class User < ApplicationRecord
 
   def editable?(user)
     user && (user.admin? || id == user.id)
-  end
-
-  def create_access_token!
-    access_tokens.create!(token: SecureRandom.hex(16))
-  end
-
-  def latest_access_token
-    access_tokens.last&.token
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,10 +32,7 @@ class User < ApplicationRecord
   end
 
   def create_access_token!
-    access_tokens.create!(
-      token: SecureRandom.hex(16),
-      expired_at: Rails.application.config.access_token_expiration_time.from_now
-    )
+    access_tokens.create!(token: SecureRandom.hex(16))
   end
 
   def latest_access_token

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,11 +35,7 @@
     <section>
       <h2>Access Tokens</h2>
 
-      <% if @user.access_token.nil? %>
-        <%= form_with url: access_tokens_path, method: :post do %>
-          <button type="submit" class="button">Generate Access Token</button>
-        <% end %>
-      <% else %>
+      <% if @user.access_token.present? %>
         <button class="disabled-button" disabled>Generate Access Token</button>
         <table>
           <tr>
@@ -57,6 +53,10 @@
             </td>
           </tr>
         </table>
+      <% else %>
+        <%= form_with url: access_tokens_path, method: :post do %>
+          <button type="submit" class="button">Generate Access Token</button>
+        <% end %>
       <% end %>
     </section>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,11 +38,11 @@
         <button type="submit" class="button">Generate Access Token</button>
       <% end %>
 
-      <% if @user.access_tokens.any? %>
+      <% if @user.access_token.present? %>
         <table>
           <tr>
             <th>Access Token</th>
-            <td id="access-token"><%= @latest_access_token %></td>
+            <td id="access-token"><%= @user.access_token.token %></td>
             <td>
               <button id="clipboard-btn" data-clipboard-action="copy" data-clipboard-target="#access-token">
                 <%= image_tag 'clippy.svg', class: 'clippy', width: 13, alt: 'Copy to clipboard', title: 'Copy to clipboard' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -41,9 +41,6 @@
         <% end %>
       <% else %>
         <button class="disabled-button" disabled>Generate Access Token</button>
-      <% end %>
-
-      <% if @user.access_token.present? %>
         <table>
           <tr>
             <th>Access Token</th>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,6 +48,11 @@
                 <%= image_tag 'clippy.svg', class: 'clippy', width: 13, alt: 'Copy to clipboard', title: 'Copy to clipboard' %>
               </button>
             </td>
+            <td>
+              <%= link_to access_token_path(@user.access_token), method: :delete, data: { confirm: 'Are you sure?' } do %>
+                <i class="fa-regular fa-trash-can" style="margin: 0 4px"></i>
+              <% end %>
+            </td>
           </tr>
         </table>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,8 +34,13 @@
   <% if @user == current_user %>
     <section>
       <h2>Access Tokens</h2>
-      <%= form_with url: access_tokens_path, method: :post do %>
-        <button type="submit" class="button">Generate Access Token</button>
+
+      <% if @user.access_token.nil? %>
+        <%= form_with url: access_tokens_path, method: :post do %>
+          <button type="submit" class="button">Generate Access Token</button>
+        <% end %>
+      <% else %>
+        <button class="disabled-button" disabled>Generate Access Token</button>
       <% end %>
 
       <% if @user.access_token.present? %>

--- a/config/initializers/client_credential_flow.rb
+++ b/config/initializers/client_credential_flow.rb
@@ -1,2 +1,0 @@
-# Set access token expiration time
-Rails.application.config.access_token_expiration_time = 2.hours

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
     :passwords => 'users/passwords'
   }
   get '/users/:name' => 'users#show', :as => 'show_user'
-  resources :access_tokens, only: :create
+  resources :access_tokens, only: %i[create destroy]
 
   resources :dictionaries do
     # Add routes for a collection route, /dictionaries/...

--- a/db/migrate/20240905071740_create_access_tokens.rb
+++ b/db/migrate/20240905071740_create_access_tokens.rb
@@ -3,7 +3,6 @@ class CreateAccessTokens < ActiveRecord::Migration[7.0]
     create_table :access_tokens do |t|
       t.references :user, null: false, foreign_key: true
       t.string :token, null: false
-      t.datetime :expired_at, null: false
 
       t.timestamps
     end

--- a/db/migrate/20240905071740_create_access_tokens.rb
+++ b/db/migrate/20240905071740_create_access_tokens.rb
@@ -3,6 +3,7 @@ class CreateAccessTokens < ActiveRecord::Migration[7.0]
     create_table :access_tokens do |t|
       t.references :user, null: false, foreign_key: true
       t.string :token, null: false
+      t.datetime :expired_at, null: false
 
       t.timestamps
     end

--- a/db/migrate/20240910064916_remove_expired_at_from_access_tokens.rb
+++ b/db/migrate/20240910064916_remove_expired_at_from_access_tokens.rb
@@ -1,0 +1,5 @@
+class RemoveExpiredAtFromAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :access_tokens, :expired_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_05_071740) do
   create_table "access_tokens", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "token", null: false
-    t.datetime "expired_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_access_tokens_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_05_071740) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_10_064916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Closes: #145

## 概要
アクセストークンの寿命や関連を修正しました。

## 実装内容
- トークン寿命が無くなったためAccessTokenテーブルから`expired_at`カラムを削除
- トークン寿命に関するロジック, メッセージを削除
- ユーザーとアクセストークンを1対1の関係に修正
- トークン削除機能を作成
- ユーザーがトークンを持っている場合、生成ボタンは押下不可に変更

#### マイグレーションについて
`expired_at`の削除はAccessTokenテーブル作成のmigrationファイルをロールバックして直接修正しましたが、別でmigrationファイルを作った方がよかったでしょうか？確認お願いします :pray:
## 動作確認
### トークンを生成していない状態
|<img width="1144" alt="image" src="https://github.com/user-attachments/assets/7a6822a6-0bb6-4839-a64c-f078d989b188">|
|:-|

### トークン作成後
トークンが表示され、生成ボタンは押せなくなります。
|<img width="1056" alt="image" src="https://github.com/user-attachments/assets/6cc3b493-7a51-486a-bb80-8ee56e4ee08f">|
|:-|

![image](https://github.com/user-attachments/assets/ea655e51-38ee-48ff-b7fe-635d0883d88b)


### トークン削除
ゴミ箱ボタンから削除可能です。
|<img width="1205" alt="image" src="https://github.com/user-attachments/assets/a1f451d0-36f3-43f4-aa8e-ffa52cada51e">|
|:-|

|<img width="1112" alt="image" src="https://github.com/user-attachments/assets/7bd8667c-9d8b-43dc-817c-ffae8c38eef2">|
|:-|

![image](https://github.com/user-attachments/assets/6d8434d1-e788-41dc-abc6-da32c50c179b)

### 認証ロジック
変更前と同様に動作します。
```
## トークンが正しい場合
201
Created
{"message":"The white entry ('test with access token14', 'test') was created."}

## トークンが不正な場合
401
Unauthorized
{"error":"The access token is missing or invalid."}
```