### PR TITLE
Jobを生成するAPIのJob削除オプション名を変更

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -61,7 +61,7 @@ class Api::V1::EntriesController < ApplicationController
   end
 
   def upload_tsv
-    if @dictionary.jobs.any? && params[:replace_task] == 'true'
+    if @dictionary.jobs.any? && params[:force] == 'true'
       @dictionary.jobs.last.destroy_if_not_running
     end
 


### PR DESCRIPTION
## 概要
Job削除オプション名を`force`に変更しました。

## 実装内容
- api/v1/entries_controller#upload_tsvのJob削除オプション名を`replace_task`から`force`に変更

## 動作確認
連続して実行しても問題なくAPIが実行できることを確認しました。
```
curl -X POST "http://localhost:3001/api/v1/entries/tsv?force=true" \
  -H "Content-Type: multipart/form-data" \
  -F "dictionary_id=EntrezGene" \
  -F "file=@test.tsv"
{"message":"Upload dictionary entries task was successfully created."}%

curl -X POST "http://localhost:3001/api/v1/entries/tsv?force=true" \
  -H "Content-Type: multipart/form-data" \
  -F "dictionary_id=EntrezGene" \
  -F "file=@test.tsv"
{"message":"Upload dictionary entries task was successfully created."}%
```