### PR TITLE
バルクアップロードの際に速度向上のためバリデーションを省略

### DIFF
--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -86,6 +86,12 @@ class LoadEntriesFromFileJob < ApplicationJob
   end
 
   def perform(dictionary, filename, mode = nil)
+    unless dictionary.entries.empty?
+      @job.message = "Dictionary upload is only available when there are no dictionary entries."
+      File.delete(filename)
+      return
+    end
+
     # file preprocessing
     # TODO: at the moment, it is hard-coded. It should be improved.
     `/usr/bin/dos2unix #{filename}`

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -47,22 +47,7 @@ class LoadEntriesFromFileJob < ApplicationJob
     private
 
     def buffer_entry(label, identifier, tags)
-      matched = entries_any? && @dictionary.entries.where(label:label, identifier:identifier)&.first
-      if matched
-        # case mode
-        # when EntryMode::GRAY
-        #   @num_skipped_entries += 1
-        # when EntryMode::WHITE
-        #   matched.be_white!
-        # when EntryMode::BLACK
-        #   matched.be_black!
-        # else
-        #   raise ArgumentError, "Unexpected mode: #{mode}"
-        # end
-        @num_skipped_entries += 1
-      else
-        @entries << [label, identifier, tags]
-      end
+      @entries << [label, identifier, tags]
       flush_entries if @entries.length >= BUFFER_SIZE
     end
 
@@ -84,11 +69,6 @@ class LoadEntriesFromFileJob < ApplicationJob
     def flush_patterns
       @dictionary.add_patterns(@patterns)
       @patterns.clear
-    end
-
-    # It is supposed to memorize whether the entries of the dictionary are empty when the class is initialized.
-    def entries_any?
-      @entries_any_p ||= !@dictionary.entries.empty?
     end
 
     # It is supposed to memorize whether the patterns of the dictionary are empty when the class is initialized.


### PR DESCRIPTION
Closes: #148 

## 概要
バルクアップロードの際に速度向上のためバリデーションを省略し、改善を行いました。

## 実装内容
- BufferToStore#buffer_entryでエントリーがすでにあるかどうかのチェックを削除
- LoadEntriesFromFileJobを辞書が空の場合にのみ実行可能に変更

## 動作確認
### 正常動作
辞書が空の場合でJobを実行します。
|<img width="1089" alt="image" src="https://github.com/user-attachments/assets/6f4f9bf3-d85c-4b1e-8f77-1270a2a2a16b">|
|:-|

正常に動作します。
|<img width="777" alt="image" src="https://github.com/user-attachments/assets/b025b846-b55f-4166-b845-6f7b254525c2">|
|:-|

|<img width="1128" alt="image" src="https://github.com/user-attachments/assets/a1ef89d8-f347-4aef-883e-783e4afb819e">|
|:-|

### 辞書にエントリーがある場合
失敗するとともにメッセージが表示されます。
|<img width="754" alt="image" src="https://github.com/user-attachments/assets/79f31cd8-338a-422e-b39a-b817f0a0e3d8">|
|:-|

## 速度比較
約60エントリーをバルクアップロードした結果です。
手動で検証したので信頼性はあまりないかもですが、パフォーマンスは良くなったように思えます。
```
改善前
1回目：427.29ms
2回目：420.91ms
3回目：400.49ms
改善後
1回目：425.63ms
2回目：325.75ms
3回目：327.23ms
```

## 実装しなかった点
既存コードから読み取ると、以前は通常のエントリーに加えてパターンエントリーもバルクアップロードが可能だったようで、専用のメソッドが残されています。
https://github.com/pubannotation/pubdictionaries/blob/199ff3abc185c2577d2f0f6050c59e353d8b1b44/app/jobs/load_entries_from_file_job.rb#L69

現状は通常エントリーのバルクアップロードのみ行える形になっていたので、
エントリーのバリデーションを削除し辞書のエントリーが空の場合にJobを実行可能にする条件は加えましたが、
パターンエントリーのバリデーションを削除し辞書のパターンエントリーが空の場合にJobを実行可能にする条件は加えませんでした。

ここは個人的な判断で行ったため、パターンエントリーの方も対応すべきか確認していただきたいです。