### PR TITLE
Jobの実行中はAPIからのエントリー操作を不可能に修正

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::EntriesController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authenticate_token
   before_action :set_dictionary
-  before_action :validate_job_not_running
+  before_action :validate_dictionary_editable
 
   rescue_from StandardError, with: :handle_standard_error
   rescue_from Exceptions::DictionaryNotFoundError, with: :dictionary_not_found
@@ -120,7 +120,7 @@ class Api::V1::EntriesController < ApplicationController
     raise Exceptions::DictionaryNotFoundError if @dictionary.nil?
   end
 
-  def validate_job_not_running
+  def validate_dictionary_editable
     if @dictionary.locked?
       render json: { error: "The last task is still in progress. Please wait a moment and try again later." }, status: :conflict
     end

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::EntriesController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authenticate_token
   before_action :set_dictionary
+  before_action :validate_job_not_running
 
   rescue_from StandardError, with: :handle_standard_error
   rescue_from Exceptions::DictionaryNotFoundError, with: :dictionary_not_found
@@ -66,14 +67,10 @@ class Api::V1::EntriesController < ApplicationController
     end
 
     if @dictionary.jobs.count > 0
-      if @dictionary.jobs.last.running?
-        render json: { error: "The last task is still in progress. Please wait a moment and try again later." }, status: :conflict
-      else
-        render json: {
-          error: "The last task is not yet dismissed. Please dismiss it and try again.",
-          task_dismiss_instruction: "To dismiss the task, send a DELETE request to /api/v1/jobs/#{@dictionary.jobs.last.id} ."
-        }, status: :conflict
-      end
+      render json: {
+        error: "The last task is not yet dismissed. Please dismiss it and try again.",
+        task_dismiss_instruction: "To dismiss the task, send a DELETE request to /api/v1/jobs/#{@dictionary.jobs.last.id} ."
+      }, status: :conflict
 
       return
     end
@@ -121,6 +118,12 @@ class Api::V1::EntriesController < ApplicationController
   def set_dictionary
     @dictionary = Dictionary.editable(current_user).find_by(name: params[:dictionary_id])
     raise Exceptions::DictionaryNotFoundError if @dictionary.nil?
+  end
+
+  def validate_job_not_running
+    if @dictionary.locked?
+      render json: { error: "The last task is still in progress. Please wait a moment and try again later." }, status: :conflict
+    end
   end
 
   def dictionary_not_found

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -170,6 +170,10 @@ class Dictionary < ApplicationRecord
     entries.empty?
   end
 
+  def locked?
+    jobs.size > 0 && jobs.first.running?
+  end
+
   def use_tags?
     !tags.empty?
   end


### PR DESCRIPTION
Closes: #151

## 概要
Jobの実行中はAPIからのエントリー操作を不可能に修正しました。

バルクアップロードJobの実行中は既存のエントリーは空なため、エントリー作成APIだけでなく全てのエントリー操作APIを失敗させるように修正を加えました。

## 実装内容
- Jobが進行中の場合、その旨のエラーメッセージを返すメソッドをAPIのbefore_actionとして設定

## 動作確認
### エントリー追加API
```
curl -X POST http://localhost:3001/api/v1/entries \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer a26fcb5f299d37e7c1f41d6eb0def1e0" \
  -d '{
        "dictionary_id": "EntrezGene",
        "label": "test-with-api-call",
        "identifier": "1"
      }'

{"error":"The last task is still in progress. Please wait a moment and try again later."}%
```

### バルクアップロードAPI
```
curl -X POST http://localhost:3001/api/v1/entries/tsv \
  -H "Content-Type: multipart/form-data" \
  -H "Authorization: Bearer a26fcb5f299d37e7c1f41d6eb0def1e0" \
  -F "dictionary_id=EntrezGene" \
  -F "file=@test.tsv"

{"error":"The last task is still in progress. Please wait a moment and try again later."}%
```