### PR TITLE
バルクアップロードの速度向上の為の最適化を実施

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,4 +1,6 @@
 class Entry < ApplicationRecord
+  INCREMENT_NUM_PER_LABEL = 101
+
   include Elasticsearch::Model
 
   settings index: {
@@ -195,7 +197,7 @@ class Entry < ApplicationRecord
     _texts = texts.map { _1.tr('{}', '()') }
     body = { analyzer: normalizer, text: _texts }.to_json
     res = request_normalize(analyzer, body)
-    JSON.parse(res.body, symbolize_names: true)[:tokens].chunk_while { |a, b| a[:position] + 1 == b[:position] }
+    JSON.parse(res.body, symbolize_names: true)[:tokens].chunk_while { |a, b| b[:position] - a[:position] != INCREMENT_NUM_PER_LABEL }
                                                         .map{|data| data.map{ _1[:token] }.join('') }
   end
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -186,15 +186,7 @@ class Entry < ApplicationRecord
     raise ArgumentError, "Empty text" unless text.present?
     _text = text.tr('{}', '()')
     body = {analyzer: normalizer, text: _text}.to_json
-    res = if analyzer.nil?
-            uri = URI(Rails.configuration.elasticsearch[:host])
-            http = Net::HTTP.new(uri.host, uri.port)
-            http.request_post('/entries/_analyze', body, {'Content-Type' => 'application/json'})
-          else
-            analyzer[:post].body = body
-            analyzer[:http].request(analyzer[:uri], analyzer[:post])
-          end
-    raise res.body unless res.kind_of? Net::HTTPSuccess
+    res = request_normalize(analyzer, body)
     (JSON.parse res.body, symbolize_names: true)[:tokens].map{|t| t[:token]}.join('')
   end
 
@@ -202,15 +194,7 @@ class Entry < ApplicationRecord
     raise ArgumentError, "Empty text in array" unless texts.present?
     _texts = texts.map { _1.tr('{}', '()') }
     body = { analyzer: normalizer, text: _texts }.to_json
-    res = if analyzer.nil?
-            uri = URI(Rails.configuration.elasticsearch[:host])
-            http = Net::HTTP.new(uri.host, uri.port)
-            http.request_post('/entries/_analyze', body, {'Content-Type' => 'application/json'})
-          else
-            analyzer[:post].body = body
-            analyzer[:http].request(analyzer[:uri], analyzer[:post])
-          end
-    raise res.body unless res.kind_of? Net::HTTPSuccess
+    res = request_normalize(analyzer, body)
     JSON.parse(res.body, symbolize_names: true)[:tokens].chunk_while { |a, b| a[:position] + 1 == b[:position] }
                                                         .map{|data| data.map{ _1[:token] }.join('') }
   end
@@ -287,5 +271,19 @@ class Entry < ApplicationRecord
 
   def update_dictionary_entries_num
     dictionary.update_entries_num
+  end
+
+  def self.request_normalize(analyzer, body)
+    res = if analyzer.nil?
+            uri = URI(Rails.configuration.elasticsearch[:host])
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.request_post('/entries/_analyze', body, {'Content-Type' => 'application/json'})
+          else
+            analyzer[:post].body = body
+            analyzer[:http].request(analyzer[:uri], analyzer[:post])
+          end
+    raise res.body unless res.kind_of? Net::HTTPSuccess
+
+    res
   end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -271,10 +271,6 @@ class Entry < ApplicationRecord
     (items1 & items2).size.to_f / (items1 | items2).size
   end
 
-  def update_dictionary_entries_num
-    dictionary.update_entries_num
-  end
-
   def self.request_normalize(analyzer, body)
     res = if analyzer.nil?
             uri = URI(Rails.configuration.elasticsearch[:host])
@@ -287,5 +283,9 @@ class Entry < ApplicationRecord
     raise res.body unless res.kind_of? Net::HTTPSuccess
 
     res
+  end
+
+  def update_dictionary_entries_num
+    dictionary.update_entries_num
   end
 end


### PR DESCRIPTION
Closes: #154 

## 概要
バルクアップロードの速度向上の為の最適化を実施しました。

## 実装内容
- Elasticsearchへの問い合わせをラベル単位からバッチ単位でまとめて行うように変更

## 動作確認
### バルクアップロード時のnormalize結果比較
使用データ
```
microfold cell of epithelium proper of appendix	id1	tag1
uterine cervix	id2	tag2|tag3
islet of Langerhans	id3	tag3
submucosa	id4	tag4
```
### 変更前
```
[#<Entry:0x00007ffff5b1ee58
  id: 73639,
  mode: 0,
  label: "microfold cell of epithelium proper of appendix",
  norm1: "microfoldcellofepitheliumproperofappendix",
  norm2: "microfoldcellepitheliumproperappendix",
  label_length: 47,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff7124f68
  id: 73640,
  mode: 0,
  label: "uterine cervix",
  norm1: "uterinecervix",
  norm2: "uterincervix",
  label_length: 14,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff86937a0
  id: 73641,
  mode: 0,
  label: "islet of Langerhans",
  norm1: "isletoflangerhans",
  norm2: "isletlangerhan",
  label_length: 19,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff8693700
  id: 73642,
  mode: 0,
  label: "submucosa",
  norm1: "submucosa",
  norm2: "submucosa",
  label_length: 9,
  identifier: "id4",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:19:09.757828000 UTC +00:00,
  dirty: false,
  score: nil>]
```
### 変更後
normalize結果が変更前と一致しています。
```
[#<Entry:0x00007ffff5049e38
  id: 73651,
  mode: 0,
  label: "microfold cell of epithelium proper of appendix",
  norm1: "microfoldcellofepitheliumproperofappendix",
  norm2: "microfoldcellepitheliumproperappendix",
  label_length: 47,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff51af660
  id: 73652,
  mode: 0,
  label: "uterine cervix",
  norm1: "uterinecervix",
  norm2: "uterincervix",
  label_length: 14,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff5675140
  id: 73653,
  mode: 0,
  label: "islet of Langerhans",
  norm1: "isletoflangerhans",
  norm2: "isletlangerhan",
  label_length: 19,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff56750a0
  id: 73654,
  mode: 0,
  label: "submucosa",
  norm1: "submucosa",
  norm2: "submucosa",
  label_length: 9,
  identifier: "id4",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 02:52:12.125469000 UTC +00:00,
  dirty: false,
  score: nil>]
```
### Jobの速度比較
バッチサイズに合わせて1万件のデータで検証しました。
#### 変更前
```
1回目：36017.99ms
2回目：36449.26ms
3回目：39413.73ms
平均：37293.66ms
```

#### 変更後
```
1回目：31370.08ms
2回目：29816.77ms
3回目：32143.39ms
平均：31110.08ms
```

約17%速度が速くなる結果となりました。