### PR TITLE
演算子によるnormalize処理の不具合を修正

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -193,6 +193,12 @@ class Entry < ApplicationRecord
   end
 
   def self.batch_normalize(texts, normalizer, analyzer = nil)
+    ## Explanation
+    # This method returns the following results from input texts corresponding to normalizer.
+    # texts:              ["abc def", "of", "ghi"]
+    # normalize1 results: ["abcdef", "of", "ghi"]
+    # normalize2 results: ["abcdef", "", "ghi"]
+
     raise ArgumentError, "Empty text in array" unless texts.present?
     _texts = texts.map { _1.tr('{}', '()') }
     body = { analyzer: normalizer, text: _texts }.to_json
@@ -200,12 +206,23 @@ class Entry < ApplicationRecord
 
     tokens = JSON.parse(res.body, symbolize_names: true)[:tokens]
 
-    # When Elasticsearch normalizes multiple texts at the same time, it combines and normalizes them as a single string.
-    # To determine each text from results, using the position value in response which is increased by 100 for each text.
+    # The 'tokens' variable is an array of tokenized words.
+    # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
+    #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
+    #           {:token=>"of", :start_offset=>8, :end_offset=>10, :type=>"<ALPHANUM>", :position=>102},
+    #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
+
+
+    # Large gaps in position values in tokens indicate text switching. It increases by 100.
+    # To determine each text from results, grouping tokens as one text if difference of position value is within the gap.
     tokens.chunk_while { |a, b| b[:position] - a[:position] <= INCREMENT_NUM_PER_TEXT }
           .reduce([[], 0]) do |(result, previous_position), words|
             # If all words in the text are removed by stopwords, the difference in position value is more than 200.
-            # Adding empty string to indicate that all words has been removed.
+            # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
+            #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
+            #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
+
+            # To obtain expected result, adding empty strings according to skipped texts number when difference of position value is over 200.
             if (words.first[:position] - previous_position) > 200
               skipped_texts_count = (words.first[:position] - previous_position) / INCREMENT_NUM_PER_TEXT - 1
               skipped_texts_count.times { result << '' }

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -197,7 +197,7 @@ class Entry < ApplicationRecord
     _texts = texts.map { _1.tr('{}', '()') }
     body = { analyzer: normalizer, text: _texts }.to_json
     res = request_normalize(analyzer, body)
-    JSON.parse(res.body, symbolize_names: true)[:tokens].chunk_while { |a, b| b[:position] - a[:position] != INCREMENT_NUM_PER_LABEL }
+    JSON.parse(res.body, symbolize_names: true)[:tokens].chunk_while { |a, b| b[:position] - a[:position] < INCREMENT_NUM_PER_LABEL }
                                                         .map{|data| data.map{ _1[:token] }.join('') }
   end
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,5 +1,5 @@
 class Entry < ApplicationRecord
-  INCREMENT_NUM_PER_LABEL = 101
+  INCREMENT_NUM_PER_TEXT = 101
 
   include Elasticsearch::Model
 
@@ -197,7 +197,10 @@ class Entry < ApplicationRecord
     _texts = texts.map { _1.tr('{}', '()') }
     body = { analyzer: normalizer, text: _texts }.to_json
     res = request_normalize(analyzer, body)
-    JSON.parse(res.body, symbolize_names: true)[:tokens].chunk_while { |a, b| b[:position] - a[:position] < INCREMENT_NUM_PER_LABEL }
+
+    # When Elasticsearch normalizes multiple texts at the same time, it combines and normalizes them as a single string.
+    # To determine each text from results, using the position value in response which is increased by 101 for each text.
+    JSON.parse(res.body, symbolize_names: true)[:tokens].chunk_while { |a, b| b[:position] - a[:position] < INCREMENT_NUM_PER_TEXT }
                                                         .map{|data| data.map{ _1[:token] }.join('') }
   end
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -199,13 +199,11 @@ class Entry < ApplicationRecord
     res = request_normalize(analyzer, body)
 
     tokens = JSON.parse(res.body, symbolize_names: true)[:tokens]
-    result = []
-    previous_position = 0
 
     # When Elasticsearch normalizes multiple texts at the same time, it combines and normalizes them as a single string.
     # To determine each text from results, using the position value in response which is increased by 100 for each text.
     tokens.chunk_while { |a, b| b[:position] - a[:position] <= INCREMENT_NUM_PER_TEXT }
-          .each do |words|
+          .reduce([[], 0]) do |(result, previous_position), words|
             # If all words in the text are removed by stopwords, the difference in position value is more than 200.
             # Adding empty string to indicate that all words has been removed.
             if (words.first[:position] - previous_position) > 200
@@ -215,9 +213,8 @@ class Entry < ApplicationRecord
 
             previous_position = words.last[:position]
             result << words.map { _1[:token] }.join('')
-          end
-
-    result
+            [result, previous_position]
+          end.first
   end
 
   private


### PR DESCRIPTION
## 概要
normalize処理においてDBに保存する`norm1`, `norm2`の値を正しく構成できていない問題があり、この問題を修正しました。

## 修正内容
Elasticsearchが返すレスポンス内の`position`キーの値が101ではない場合は同一ラベルという判断をしていました。
ただ、ラベルの前後に`of`などのnormalize処理によって省略される値がある場合、`position`キーの値が101以上になります。
この場合に同一ラベルの判断に不具合が生じていたので、判断内容を
"差が101じゃない場合は同一ラベル"
から
"差が101より少ない場合、同一ラベル"
と変更することで不具合に対応しました。

## 動作確認
使用データ
```
appendix of	id1	tag1
uterine cervix	id2	tag2|tag3
of islet of Langerhans	id3	tag3
submucosa	id4	tag4
```

### 修正前
```
[#<Entry:0x00007ffff6d84cf0
  id: 143687,
  mode: 0,
  label: "appendix of",
  norm1: "appendixof",
  norm2: "appendixuterincervixisletlangerhan",
  label_length: 11,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff716be68
  id: 143688,
  mode: 0,
  label: "uterine cervix",
  norm1: "uterinecervix",
  norm2: "submucosa",
  label_length: 14,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff757f518
  id: 143689,
  mode: 0,
  label: "of islet of Langerhans",
  norm1: "ofisletoflangerhans",
  norm2: nil,
  label_length: 22,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff757f478
  id: 143690,
  mode: 0,
  label: "submucosa",
  norm1: "submucosa",
  norm2: nil,
  label_length: 9,
  identifier: "id4",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:08:33.454664000 UTC +00:00,
  dirty: false,
  score: nil>]
```

### 修正後
```
[#<Entry:0x00007ffff6d6eec8
  id: 143683,
  mode: 0,
  label: "appendix of",
  norm1: "appendixof",
  norm2: "appendix",
  label_length: 11,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff7073628
  id: 143684,
  mode: 0,
  label: "uterine cervix",
  norm1: "uterinecervix",
  norm2: "uterincervix",
  label_length: 14,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff78bfb60
  id: 143685,
  mode: 0,
  label: "of islet of Langerhans",
  norm1: "ofisletoflangerhans",
  norm2: "isletlangerhan",
  label_length: 22,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff78bfa20
  id: 143686,
  mode: 0,
  label: "submucosa",
  norm1: "submucosa",
  norm2: "submucosa",
  label_length: 9,
  identifier: "id4",
  dictionary_id: 1,
  created_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  updated_at: Wed, 18 Sep 2024 07:07:38.745652000 UTC +00:00,
  dirty: false,
  score: nil>]
```