### PR TITLE
normalize関連の処理をリファクタリング

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -41,7 +41,7 @@ class EntriesController < ApplicationController
 
       message = nil
       ActiveRecord::Base.transaction do
-        entry = dictionary.new_entry(label, identifier, nil, EntryMode::WHITE, true)
+        entry = dictionary.new_entry(label, identifier, EntryMode::WHITE, true)
 
         tag_ids = params[:tags] || []
         entry.tag_ids = tag_ids

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -13,12 +13,7 @@ class LoadEntriesFromFileJob < ApplicationJob
       @entries = []
       @patterns = []
 
-      analyzer_url = URI.parse("#{Rails.configuration.elasticsearch[:host]}/entries/_analyze")
-      @analyzer = {
-        uri: analyzer_url,
-        http: Net::HTTP::Persistent.new,
-        post: Net::HTTP::Post.new(analyzer_url.request_uri, 'Content-Type' => 'application/json')
-      }
+      @analyzer = Analyzer.new(use_persistent: true)
 
       @num_skipped_entries = 0
       @num_skipped_patterns = 0
@@ -37,7 +32,7 @@ class LoadEntriesFromFileJob < ApplicationJob
     def finalize
       flush_entries unless @entries.empty?
       flush_patterns unless @patterns.empty?
-      @analyzer && @analyzer[:http] && @analyzer[:http].shutdown
+      @analyzer && @analyzer.shutdown
     end
 
     def result

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -32,7 +32,7 @@ class LoadEntriesFromFileJob < ApplicationJob
     def finalize
       flush_entries unless @entries.empty?
       flush_patterns unless @patterns.empty?
-      @analyzer && @analyzer.shutdown
+      @analyzer&.shutdown
     end
 
     def result

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -10,6 +10,7 @@ class Analyzer
         Net::HTTP.new(@uri.host, @uri.port)
       end
     @post = Net::HTTP::Post.new(@uri.request_uri, 'Content-Type' => 'application/json')
+    @use_persistent = use_persistent
   end
 
   def normalize(text, normalizer)
@@ -71,7 +72,12 @@ class Analyzer
 
   def tokenize(body)
     @post.body = body
-    response = @http.request(@uri, @post)
+    response =
+      if @use_persistent
+        @http.request(@uri, @post)
+      else
+        @http.request(@post)
+      end
 
     raise response.body unless response.kind_of? Net::HTTPSuccess
     response

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -14,7 +14,7 @@ class Analyzer
   end
 
   def normalize(text, normalizer)
-    raise ArgumentError, "Empty text" unless text.present?
+    raise ArgumentError, "Empty text" if text.blank?
     _text = text.tr('{}', '()')
     body = { analyzer: normalizer, text: _text }.to_json
     response = tokenize(body)
@@ -29,7 +29,7 @@ class Analyzer
     # normalize1 results: ["abcdef", "of", "ghi"]
     # normalize2 results: ["abcdef", "", "ghi"]
 
-    raise ArgumentError, "Empty text in array" unless texts.present?
+    raise ArgumentError, "Empty text in array" if texts.empty? || texts.any?{ _1.empty? }
     _texts = texts.map { _1.tr('{}', '()') }
     body = { analyzer: normalizer, text: _texts }.to_json
     response = tokenize(body)

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -1,0 +1,14 @@
+class Analyzer
+
+  def initialize(use_persistent: false)
+    @uri = URI.parse("#{Rails.configuration.elasticsearch[:host]}/entries/_analyze")
+    @http =
+      if use_persistent
+        Net::HTTP::Persistent.new
+      else
+        Net::HTTP.new(@uri.host, @uri.port)
+      end
+    @post = Net::HTTP::Post.new(@uri.request_uri, 'Content-Type' => 'application/json')
+  end
+
+end

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -19,7 +19,7 @@ class Analyzer
     body = { analyzer: normalizer, text: _text }.to_json
     response = tokenize(body)
 
-    (JSON.parse response.body, symbolize_names: true)[:tokens].map{ _1[:token] }.join('')
+    JSON.parse(response.body, symbolize_names: true)[:tokens].map{ _1[:token] }.join('')
   end
 
   def batch_normalize(texts, normalizer)

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -1,4 +1,5 @@
 class Analyzer
+  INCREMENT_NUM_PER_TEXT = 100
 
   def initialize(use_persistent: false)
     @uri = URI.parse("#{Rails.configuration.elasticsearch[:host]}/entries/_analyze")
@@ -11,4 +12,59 @@ class Analyzer
     @post = Net::HTTP::Post.new(@uri.request_uri, 'Content-Type' => 'application/json')
   end
 
+  def batch_normalize(texts, normalizer)
+    ## Explanation
+    # This method returns the following results from input texts corresponding to normalizer.
+    # texts:              ["abc def", "of", "ghi"]
+    # normalize1 results: ["abcdef", "of", "ghi"]
+    # normalize2 results: ["abcdef", "", "ghi"]
+
+    raise ArgumentError, "Empty text in array" unless texts.present?
+    _texts = texts.map { _1.tr('{}', '()') }
+    body = { analyzer: normalizer, text: _texts }.to_json
+    response = tokenize(body)
+
+    tokens = JSON.parse(response.body, symbolize_names: true)[:tokens]
+
+    # The 'tokens' variable is an array of tokenized words.
+    # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
+    #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
+    #           {:token=>"of", :start_offset=>8, :end_offset=>10, :type=>"<ALPHANUM>", :position=>102},
+    #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
+
+
+    # Large gaps in position values in tokens indicate text switching. It increases by 100.
+    # To determine each text from results, grouping tokens as one text if difference of position value is within the gap.
+    tokens.chunk_while { |a, b| b[:position] - a[:position] <= INCREMENT_NUM_PER_TEXT }
+          .reduce([[], 0]) do |(result, previous_position), words|
+            # If all words in the text are removed by stopwords, the difference in position value is more than 200.
+            # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
+            #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
+            #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
+
+            # To obtain expected result, adding empty strings according to skipped texts number when difference of position value is over 200.
+            if (words.first[:position] - previous_position) > 200
+              skipped_texts_count = (words.first[:position] - previous_position) / INCREMENT_NUM_PER_TEXT - 1
+              skipped_texts_count.times { result << '' }
+            end
+
+            previous_position = words.last[:position]
+            result << words.map { _1[:token] }.join('')
+            [result, previous_position]
+          end.first
+  end
+
+  def shutdown
+    @http.shutdown
+  end
+
+  private
+
+  def tokenize(body)
+    @post.body = body
+    response = @http.request(@uri, @post)
+
+    raise response.body unless response.kind_of? Net::HTTPSuccess
+    response
+  end
 end

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -12,6 +12,15 @@ class Analyzer
     @post = Net::HTTP::Post.new(@uri.request_uri, 'Content-Type' => 'application/json')
   end
 
+  def normalize(text, normalizer)
+    raise ArgumentError, "Empty text" unless text.present?
+    _text = text.tr('{}', '()')
+    body = { analyzer: normalizer, text: _text }.to_json
+    response = tokenize(body)
+
+    (JSON.parse response.body, symbolize_names: true)[:tokens].map{ _1[:token] }.join('')
+  end
+
   def batch_normalize(texts, normalizer)
     ## Explanation
     # This method returns the following results from input texts corresponding to normalizer.

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -245,13 +245,13 @@ class Dictionary < ApplicationRecord
     end
   end
 
-  def add_entries(raw_entries, normalizer = nil)
+  def add_entries(raw_entries, analyzer = nil)
     # black_count = raw_entries.count{|e| e[2] == EntryMode::BLACK}
 
     transaction do
       # prepare for enrich entries
       labels = raw_entries.map { |label, _, _| label }
-      norm1s, norm2s = batch_normalize_entries(labels, normalizer)
+      norm1s, norm2s = batch_normalize_entries(labels, analyzer)
 
       # index tags & enrich entries
       entry_i_tags = []
@@ -294,9 +294,11 @@ class Dictionary < ApplicationRecord
     end
   end
 
-  def batch_normalize_entries(labels, normalizer)
-    norm1s = Entry.batch_normalize(labels, normalizer1, normalizer)
-    norm2s = Entry.batch_normalize(labels, normalizer2, normalizer)
+  def batch_normalize_entries(labels, analyzer)
+    analyzer ||= Analyzer.new
+
+    norm1s = analyzer.batch_normalize(labels, normalizer1)
+    norm2s = analyzer.batch_normalize(labels, normalizer2)
     [norm1s, norm2s]
   rescue => e
     raise ArgumentError, "Entries are rejected: #{e.message} #{e.backtrace.join("\n")}."

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -304,9 +304,9 @@ class Dictionary < ApplicationRecord
     raise ArgumentError, "Entries are rejected: #{e.message} #{e.backtrace.join("\n")}."
   end
 
-  def new_entry(label, identifier, normalizer = nil, mode = EntryMode::GRAY, dirty = false)
-    norm1 = normalize1(label, normalizer)
-    norm2 = normalize2(label, normalizer)
+  def new_entry(label, identifier, analyzer = nil, mode = EntryMode::GRAY, dirty = false)
+    norm1 = normalize1(label, analyzer)
+    norm2 = normalize2(label, analyzer)
     Entry.new(label:label, identifier:identifier, norm1:norm1, norm2:norm2, label_length:label.length, mode:mode, dirty:dirty, dictionary_id: self.id)
   rescue => e
     raise ArgumentError, "The entry, [#{label}, #{identifier}], is rejected: #{e.message} #{e.backtrace.join("\n")}."
@@ -657,11 +657,13 @@ class Dictionary < ApplicationRecord
   # * (string) text  - Input text.
   #
   def normalize1(text, analyzer = nil)
-    Entry.normalize(text, normalizer1, analyzer)
+    analyzer ||= Analyzer.new
+    analyzer.normalize(text, normalizer1)
   end
 
   def self.normalize1(text, analyzer = nil)
-    Entry.normalize(text, 'normalizer1', analyzer)
+    analyzer ||= Analyzer.new
+    analyzer.normalize(text, 'normalizer1')
   end
 
   # Get typographic and morphosyntactic normalization of an input text using an analyzer of ElasticSearch.
@@ -669,11 +671,13 @@ class Dictionary < ApplicationRecord
   # * (string) text  - Input text.
   #
   def normalize2(text, analyzer = nil)
-    Entry.normalize(text, normalizer2, analyzer)
+    analyzer ||= Analyzer.new
+    analyzer.normalize(text, normalizer2)
   end
 
   def self.normalize2(text, analyzer = nil)
-    Entry.normalize(text, 'normalizer2', analyzer)
+    analyzer ||= Analyzer.new
+    analyzer.normalize(text, 'normalizer2')
   end
 
   def normalizer1

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -245,7 +245,7 @@ class Dictionary < ApplicationRecord
     end
   end
 
-  def add_entries(raw_entries, analyzer = nil)
+  def add_entries(raw_entries, analyzer = Analyzer.new)
     # black_count = raw_entries.count{|e| e[2] == EntryMode::BLACK}
 
     transaction do
@@ -295,8 +295,6 @@ class Dictionary < ApplicationRecord
   end
 
   def batch_normalize_entries(labels, analyzer)
-    analyzer ||= Analyzer.new
-
     norm1s = analyzer.batch_normalize(labels, normalizer1)
     norm2s = analyzer.batch_normalize(labels, normalizer2)
     [norm1s, norm2s]
@@ -304,7 +302,7 @@ class Dictionary < ApplicationRecord
     raise ArgumentError, "Entries are rejected: #{e.message} #{e.backtrace.join("\n")}."
   end
 
-  def new_entry(label, identifier, analyzer = nil, mode = EntryMode::GRAY, dirty = false)
+  def new_entry(label, identifier, mode = EntryMode::GRAY, dirty = false, analyzer = Analyzer.new)
     norm1 = normalize1(label, analyzer)
     norm2 = normalize2(label, analyzer)
     Entry.new(label:label, identifier:identifier, norm1:norm1, norm2:norm2, label_length:label.length, mode:mode, dirty:dirty, dictionary_id: self.id)
@@ -313,7 +311,7 @@ class Dictionary < ApplicationRecord
   end
 
   def create_entry!(label, identifier, tag_ids = [])
-    entry = new_entry(label, identifier, nil, EntryMode::WHITE, true)
+    entry = new_entry(label, identifier, EntryMode::WHITE, true)
     entry.tag_ids = tag_ids
     entry.save!
 
@@ -656,13 +654,11 @@ class Dictionary < ApplicationRecord
   #
   # * (string) text  - Input text.
   #
-  def normalize1(text, analyzer = nil)
-    analyzer ||= Analyzer.new
+  def normalize1(text, analyzer = Analyzer.new)
     analyzer.normalize(text, normalizer1)
   end
 
-  def self.normalize1(text, analyzer = nil)
-    analyzer ||= Analyzer.new
+  def self.normalize1(text, analyzer = Analyzer.new)
     analyzer.normalize(text, 'normalizer1')
   end
 
@@ -670,13 +666,11 @@ class Dictionary < ApplicationRecord
   #
   # * (string) text  - Input text.
   #
-  def normalize2(text, analyzer = nil)
-    analyzer ||= Analyzer.new
+  def normalize2(text, analyzer = Analyzer.new)
     analyzer.normalize(text, normalizer2)
   end
 
-  def self.normalize2(text, analyzer = nil)
-    analyzer ||= Analyzer.new
+  def self.normalize2(text, analyzer = Analyzer.new)
     analyzer.normalize(text, 'normalizer2')
   end
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,6 +1,4 @@
 class Entry < ApplicationRecord
-  INCREMENT_NUM_PER_TEXT = 100
-
   include Elasticsearch::Model
 
   settings index: {
@@ -190,48 +188,6 @@ class Entry < ApplicationRecord
     body = {analyzer: normalizer, text: _text}.to_json
     res = request_normalize(analyzer, body)
     (JSON.parse res.body, symbolize_names: true)[:tokens].map{|t| t[:token]}.join('')
-  end
-
-  def self.batch_normalize(texts, normalizer, analyzer = nil)
-    ## Explanation
-    # This method returns the following results from input texts corresponding to normalizer.
-    # texts:              ["abc def", "of", "ghi"]
-    # normalize1 results: ["abcdef", "of", "ghi"]
-    # normalize2 results: ["abcdef", "", "ghi"]
-
-    raise ArgumentError, "Empty text in array" unless texts.present?
-    _texts = texts.map { _1.tr('{}', '()') }
-    body = { analyzer: normalizer, text: _texts }.to_json
-    res = request_normalize(analyzer, body)
-
-    tokens = JSON.parse(res.body, symbolize_names: true)[:tokens]
-
-    # The 'tokens' variable is an array of tokenized words.
-    # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
-    #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
-    #           {:token=>"of", :start_offset=>8, :end_offset=>10, :type=>"<ALPHANUM>", :position=>102},
-    #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
-
-
-    # Large gaps in position values in tokens indicate text switching. It increases by 100.
-    # To determine each text from results, grouping tokens as one text if difference of position value is within the gap.
-    tokens.chunk_while { |a, b| b[:position] - a[:position] <= INCREMENT_NUM_PER_TEXT }
-          .reduce([[], 0]) do |(result, previous_position), words|
-            # If all words in the text are removed by stopwords, the difference in position value is more than 200.
-            # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
-            #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
-            #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
-
-            # To obtain expected result, adding empty strings according to skipped texts number when difference of position value is over 200.
-            if (words.first[:position] - previous_position) > 200
-              skipped_texts_count = (words.first[:position] - previous_position) / INCREMENT_NUM_PER_TEXT - 1
-              skipped_texts_count.times { result << '' }
-            end
-
-            previous_position = words.last[:position]
-            result << words.map { _1[:token] }.join('')
-            [result, previous_position]
-          end.first
   end
 
   private


### PR DESCRIPTION
## 概要
normalize関連の処理をリファクタリングしました。

## 行ったこと
- Analyzerクラスの作成
- Entryモデルのnormalize処理をAnalyzerクラスに移動
- その他引数名の改善など

## 動作確認
### 通常のエントリー作成
Analyzer#normalizeと変更を加えたエントリー作成周りの処理が動作することを確認

#### 結果
|<img width="1033" alt="image" src="https://github.com/user-attachments/assets/42327a3d-b887-4622-a9aa-581a3f39e4bf">|
|:-|

### バルクアップロード
Analyzer#batch_normalizeと変更を加えたバルクアップロード周りの処理が動作することを確認

#### テストデータ
```
abc def	id1
of	id2
hig	id3
```

#### 結果
(※ progressが3/5になっているのはローカルでバルクアップロードを行うために追加した設定のせいです)
|<img width="705" alt="image" src="https://github.com/user-attachments/assets/583d07e3-2bad-4759-a59e-65b6de42d1cf">|
|:-|

|<img width="1048" alt="image" src="https://github.com/user-attachments/assets/f189f459-69b2-4a77-9f43-ef3049d8bcb1">|
|:-|

```
[#<Entry:0x00007ffff6e5d230
  id: 153896,
  mode: 0,
  label: "abc def",
  norm1: "abcdef",
  norm2: "abcdef",
  label_length: 7,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Fri, 20 Sep 2024 08:17:19.720588000 UTC +00:00,
  updated_at: Fri, 20 Sep 2024 08:17:19.720588000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff712cbc8
  id: 153897,
  mode: 0,
  label: "of",
  norm1: "of",
  norm2: "",
  label_length: 2,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Fri, 20 Sep 2024 08:17:19.720588000 UTC +00:00,
  updated_at: Fri, 20 Sep 2024 08:17:19.720588000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff75794d8
  id: 153898,
  mode: 0,
  label: "hig",
  norm1: "hig",
  norm2: "hig",
  label_length: 3,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Fri, 20 Sep 2024 08:17:19.720588000 UTC +00:00,
  updated_at: Fri, 20 Sep 2024 08:17:19.720588000 UTC +00:00,
  dirty: false,
  score: nil>]
```