### PR TITLE
不要なデフォルト引数の設定を削除

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -244,7 +244,7 @@ class Dictionary < ApplicationRecord
     end
   end
 
-  def add_entries(raw_entries, analyzer = Analyzer.new)
+  def add_entries(raw_entries, analyzer)
     # black_count = raw_entries.count{|e| e[2] == EntryMode::BLACK}
 
     transaction do


### PR DESCRIPTION
## 概要
CloneDictionaryJobの削除によってDictionary#add_entriesの呼び出しもとが1つとなり、デフォルト引数を使用するルートがなくなったためデフォルト引数を削除しました。