### PR TITLE
エントリー処理周りのリファクタリング

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -41,7 +41,7 @@ class EntriesController < ApplicationController
 
       message = nil
       ActiveRecord::Base.transaction do
-        entry = dictionary.new_entry(label, identifier, EntryMode::WHITE, true)
+        entry = dictionary.new_entry(label, identifier)
 
         tag_ids = params[:tags] || []
         entry.tag_ids = tag_ids

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -4,74 +4,6 @@
 class LoadEntriesFromFileJob < ApplicationJob
   queue_as :upload
 
-  class BufferToStore
-    BUFFER_SIZE = 10000
-
-    def initialize(dictionary)
-      @dictionary = dictionary
-
-      @entries = []
-      @patterns = []
-
-      @analyzer = Analyzer.new(use_persistent: true)
-
-      @num_skipped_entries = 0
-      @num_skipped_patterns = 0
-    end
-
-    def add_entry(label, identifier, tags)
-      # case mode
-      # when EntryMode::PATTERN
-      #   buffer_pattern(label, identifier)
-      # else
-      #   buffer_entry(label, identifier, mode)
-      # end
-      buffer_entry(label, identifier, tags)
-    end
-
-    def finalize
-      flush_entries unless @entries.empty?
-      flush_patterns unless @patterns.empty?
-      @analyzer&.shutdown
-    end
-
-    def result
-      [@num_skipped_entries, @num_skipped_patterns]
-    end
-
-    private
-
-    def buffer_entry(label, identifier, tags)
-      @entries << [label, identifier, tags]
-      flush_entries if @entries.length >= BUFFER_SIZE
-    end
-
-    def buffer_pattern(expression, identifier)
-      matched = patterns_any? && @dictionary.patterns.where(expression:expression, identifier:identifier)&.first
-      if matched
-        @num_skipped_patterns += 1
-      else
-        @patterns << [expression, identifier]
-      end
-      flush_patterns if @patterns.length >= BUFFER_SIZE
-    end
-
-    def flush_entries
-      @dictionary.add_entries(@entries, @analyzer)
-      @entries.clear
-    end
-
-    def flush_patterns
-      @dictionary.add_patterns(@patterns)
-      @patterns.clear
-    end
-
-    # It is supposed to memorize whether the patterns of the dictionary are empty when the class is initialized.
-    def patterns_any?
-      @patterns_any_p ||= !@dictionary.patterns.empty?
-    end
-  end
-
   def self.copy_file_and_perform(dictionary, source_filepath)
     target_filepath = File.join('tmp', "upload-#{dictionary.name}-#{Time.now.to_s[0..18].gsub(/[ :]/, '-')}")
     FileUtils.cp source_filepath, target_filepath
@@ -98,7 +30,7 @@ class LoadEntriesFromFileJob < ApplicationJob
       @job.update_attribute(:num_dones, 0)
     end
 
-    buffer = BufferToStore.new(dictionary)
+    buffer = LoadEntriesFromFileJob::BufferToStore.new(dictionary)
 
     File.open(filename, 'r') do |f|
       f.each_line do |line|

--- a/app/jobs/load_entries_from_file_job/buffer_to_store.rb
+++ b/app/jobs/load_entries_from_file_job/buffer_to_store.rb
@@ -51,8 +51,14 @@ class LoadEntriesFromFileJob::BufferToStore
   end
 
   def flush_entries
-    @dictionary.add_entries(@entries, @analyzer)
+    labels = @entries.map(&:first)
+    norm1list, norm2list = @analyzer.batch_normalize labels,
+                                                     @dictionary.normalizer1,
+                                                     @dictionary.normalizer2
+    @dictionary.add_entries(@entries, norm1list, norm2list)
     @entries.clear
+  rescue => e
+    raise ArgumentError, "Entries are rejected: #{e.message} #{e.backtrace.join("\n")}."
   end
 
   def flush_patterns

--- a/app/jobs/load_entries_from_file_job/buffer_to_store.rb
+++ b/app/jobs/load_entries_from_file_job/buffer_to_store.rb
@@ -1,0 +1,67 @@
+class LoadEntriesFromFileJob::BufferToStore
+  BUFFER_SIZE = 10000
+
+  def initialize(dictionary)
+    @dictionary = dictionary
+
+    @entries = []
+    @patterns = []
+
+    @analyzer = Analyzer.new(use_persistent: true)
+
+    @num_skipped_entries = 0
+    @num_skipped_patterns = 0
+  end
+
+  def add_entry(label, identifier, tags)
+    # case mode
+    # when EntryMode::PATTERN
+    #   buffer_pattern(label, identifier)
+    # else
+    #   buffer_entry(label, identifier, mode)
+    # end
+    buffer_entry(label, identifier, tags)
+  end
+
+  def finalize
+    flush_entries unless @entries.empty?
+    flush_patterns unless @patterns.empty?
+    @analyzer&.shutdown
+  end
+
+  def result
+    [@num_skipped_entries, @num_skipped_patterns]
+  end
+
+  private
+
+  def buffer_entry(label, identifier, tags)
+    @entries << [label, identifier, tags]
+    flush_entries if @entries.length >= BUFFER_SIZE
+  end
+
+  def buffer_pattern(expression, identifier)
+    matched = patterns_any? && @dictionary.patterns.where(expression:expression, identifier:identifier)&.first
+    if matched
+      @num_skipped_patterns += 1
+    else
+      @patterns << [expression, identifier]
+    end
+    flush_patterns if @patterns.length >= BUFFER_SIZE
+  end
+
+  def flush_entries
+    @dictionary.add_entries(@entries, @analyzer)
+    @entries.clear
+  end
+
+  def flush_patterns
+    @dictionary.add_patterns(@patterns)
+    @patterns.clear
+  end
+
+  # It is supposed to memorize whether the patterns of the dictionary are empty when the class is initialized.
+  def patterns_any?
+    @patterns_any_p ||= !@dictionary.patterns.empty?
+  end
+end

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -22,7 +22,7 @@ class Analyzer
     JSON.parse(response.body, symbolize_names: true)[:tokens].map{ _1[:token] }.join('')
   end
 
-  def batch_normalize(texts, normalizer)
+  def batch_normalize(texts, *normalizers)
     ## Explanation
     # This method returns the following results from input texts corresponding to normalizer.
     # texts:              ["abc def", "of", "ghi"]
@@ -31,37 +31,40 @@ class Analyzer
 
     raise ArgumentError, "Empty text in array" if texts.empty? || texts.any?{ _1.empty? }
     _texts = texts.map { _1.tr('{}', '()') }
-    body = { analyzer: normalizer, text: _texts }.to_json
-    response = tokenize(body)
 
-    tokens = JSON.parse(response.body, symbolize_names: true)[:tokens]
+    normalizers.map do |normalizer|
+      body = { analyzer: normalizer, text: _texts }.to_json
+      response = tokenize(body)
 
-    # The 'tokens' variable is an array of tokenized words.
-    # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
-    #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
-    #           {:token=>"of", :start_offset=>8, :end_offset=>10, :type=>"<ALPHANUM>", :position=>102},
-    #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
+      tokens = JSON.parse(response.body, symbolize_names: true)[:tokens]
+
+      # The 'tokens' variable is an array of tokenized words.
+      # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
+      #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
+      #           {:token=>"of", :start_offset=>8, :end_offset=>10, :type=>"<ALPHANUM>", :position=>102},
+      #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
 
 
-    # Large gaps in position values in tokens indicate text switching. It increases by 100.
-    # To determine each text from results, grouping tokens as one text if difference of position value is within the gap.
-    tokens.chunk_while { |a, b| b[:position] - a[:position] <= INCREMENT_NUM_PER_TEXT }
-          .reduce([[], 0]) do |(result, previous_position), words|
-            # If all words in the text are removed by stopwords, the difference in position value is more than 200.
-            # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
-            #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
-            #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
+      # Large gaps in position values in tokens indicate text switching. It increases by 100.
+      # To determine each text from results, grouping tokens as one text if difference of position value is within the gap.
+      tokens.chunk_while { |a, b| b[:position] - a[:position] <= INCREMENT_NUM_PER_TEXT }
+            .reduce([[], 0]) do |(result, previous_position), words|
+              # If all words in the text are removed by stopwords, the difference in position value is more than 200.
+              # example: [{:token=>"abc", :start_offset=>0, :end_offset=>3, :type=>"<ALPHANUM>", :position=>0},
+              #           {:token=>"def", :start_offset=>4, :end_offset=>7, :type=>"<ALPHANUM>", :position=>1},
+              #           {:token=>"ghi", :start_offset=>11, :end_offset=>14, :type=>"<ALPHANUM>", :position=>203}]
 
-            # To obtain expected result, adding empty strings according to skipped texts number when difference of position value is over 200.
-            if (words.first[:position] - previous_position) > 200
-              skipped_texts_count = (words.first[:position] - previous_position) / INCREMENT_NUM_PER_TEXT - 1
-              skipped_texts_count.times { result << '' }
-            end
+              # To obtain expected result, adding empty strings according to skipped texts number when difference of position value is over 200.
+              if (words.first[:position] - previous_position) > 200
+                skipped_texts_count = (words.first[:position] - previous_position) / INCREMENT_NUM_PER_TEXT - 1
+                skipped_texts_count.times { result << '' }
+              end
 
-            previous_position = words.last[:position]
-            result << words.map { _1[:token] }.join('')
-            [result, previous_position]
-          end.first
+              previous_position = words.last[:position]
+              result << words.map { _1[:token] }.join('')
+              [result, previous_position]
+            end.first
+    end
   end
 
   def shutdown

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -290,12 +290,16 @@ class Dictionary < ApplicationRecord
   end
 
   def new_entry(label, identifier)
-    mode = EntryMode::WHITE
-    dirty = true
     analyzer = Analyzer.new
     norm1 = normalize1(label, analyzer)
     norm2 = normalize2(label, analyzer)
-    Entry.new(label:label, identifier:identifier, norm1:norm1, norm2:norm2, label_length:label.length, mode:mode, dirty:dirty, dictionary_id: self.id)
+    entries.build(label: label,
+                  identifier: identifier,
+                  norm1: norm1,
+                  norm2: norm2,
+                  label_length: label.length,
+                  mode: EntryMode::WHITE,
+                  dirty: true)
   rescue => e
     raise ArgumentError, "The entry, [#{label}, #{identifier}], is rejected: #{e.message} #{e.backtrace.join("\n")}."
   end
@@ -636,6 +640,7 @@ class Dictionary < ApplicationRecord
       .active
       .pluck(:norm2)
       .uniq
+      .compact # to avoid error
       .each{|norm2| db.insert norm2}
 
     db.close

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -301,7 +301,10 @@ class Dictionary < ApplicationRecord
     raise ArgumentError, "Entries are rejected: #{e.message} #{e.backtrace.join("\n")}."
   end
 
-  def new_entry(label, identifier, mode = EntryMode::GRAY, dirty = false, analyzer = Analyzer.new)
+  def new_entry(label, identifier)
+    mode = EntryMode::WHITE
+    dirty = true
+    analyzer = Analyzer.new
     norm1 = normalize1(label, analyzer)
     norm2 = normalize2(label, analyzer)
     Entry.new(label:label, identifier:identifier, norm1:norm1, norm2:norm2, label_length:label.length, mode:mode, dirty:dirty, dictionary_id: self.id)
@@ -310,7 +313,7 @@ class Dictionary < ApplicationRecord
   end
 
   def create_entry!(label, identifier, tag_ids = [])
-    entry = new_entry(label, identifier, EntryMode::WHITE, true)
+    entry = new_entry(label, identifier)
     entry.tag_ids = tag_ids
     entry.save!
 


### PR DESCRIPTION
## 概要
エントリー処理周りのリファクタリングを行いました。

## 行なったこと
- Dictionary#new_entryのデフォルト引数をローカル変数に変更
  - https://github.com/pubannotation/pubdictionaries/pull/160/commits/302a63b1106e76ee0cac5ba28868db7d74454d35
- LoadEntriesFromFileJob::BufferToStoreを別ファイルに移動
  - https://github.com/pubannotation/pubdictionaries/pull/160/commits/3593cc856af8dc8724e0a8f580633a696c58e2eb
- BufferToStoreクラス内でanalyzerの初期化、呼び出し、解放を完結するように変更
  - https://github.com/pubannotation/pubdictionaries/pull/160/commits/4e1e7d58d02df22221db80400ee67fec7a8a0ee8

## 動作確認
### エントリー作成
|<img width="1087" alt="image" src="https://github.com/user-attachments/assets/f15243a8-719e-4ffe-85f1-bc5ec4f76352">|
|:-|

ログ
![image](https://github.com/user-attachments/assets/8cc7f4e3-7d54-4967-82a6-e1434820e41f)

### バルクアップロード
|<img width="484" alt="image" src="https://github.com/user-attachments/assets/361d33a6-8895-4317-8861-67077dc173df">|
|:-|

|<img width="1069" alt="image" src="https://github.com/user-attachments/assets/69661212-b6e8-4076-9c88-b1b6ae13424b">|
|:-|

```
irb(main):001> Dictionary.first.entries
  Dictionary Load (2.2ms)  SELECT "dictionaries".* FROM "dictionaries" ORDER BY "dictionaries"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Entry Load (1.3ms)  SELECT "entries".* FROM "entries" WHERE "entries"."dictionary_id" = $1  [["dictionary_id", 1]]
=>
[#<Entry:0x00007ffff6d6bed0
  id: 396584,
  mode: 0,
  label: "abc def",
  norm1: "abcdef",
  norm2: "abcdef",
  label_length: 7,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Wed, 25 Sep 2024 01:41:55.117367000 UTC +00:00,
  updated_at: Wed, 25 Sep 2024 01:41:55.117367000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff70f1e60
  id: 396585,
  mode: 0,
  label: "of",
  norm1: "of",
  norm2: "",
  label_length: 2,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Wed, 25 Sep 2024 01:41:55.117367000 UTC +00:00,
  updated_at: Wed, 25 Sep 2024 01:41:55.117367000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff7697b30
  id: 396586,
  mode: 0,
  label: "hig",
  norm1: "hig",
  norm2: "hig",
  label_length: 3,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Wed, 25 Sep 2024 01:41:55.117367000 UTC +00:00,
  updated_at: Wed, 25 Sep 2024 01:41:55.117367000 UTC +00:00,
  dirty: false,
  score: nil>]
```