### PR TITLE
細かい点をリファクタリング

### DIFF
--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -13,10 +13,7 @@ class LoadEntriesFromFileJob < ApplicationJob
   end
 
   def perform(dictionary, filename, mode = nil)
-    unless dictionary.entries.empty?
-      @job.message = "Dictionary upload is only available when there are no dictionary entries."
-      return
-    end
+    raise ArgumentError, "Dictionary upload is only available when there are no dictionary entries." unless dictionary.entries.empty?
 
     # file preprocessing
     format_and_rewrite(filename)

--- a/app/jobs/load_entries_from_file_job.rb
+++ b/app/jobs/load_entries_from_file_job.rb
@@ -22,10 +22,9 @@ class LoadEntriesFromFileJob < ApplicationJob
     format_and_rewrite(filename)
 
     num_entries = File.read(filename).each_line.count
-    if @job
-      @job.update_attribute(:num_items, num_entries)
-      @job.update_attribute(:num_dones, 0)
-    end
+
+    @job.update_attribute(:num_items, num_entries)
+    @job.update_attribute(:num_dones, 0)
 
     buffer = LoadEntriesFromFileJob::BufferToStore.new(dictionary)
 
@@ -36,7 +35,7 @@ class LoadEntriesFromFileJob < ApplicationJob
 
         buffer.add_entry(label, id, tags)
 
-        @job.increment!(:num_dones) if @job
+        @job.increment!(:num_dones)
 
         if suspended?
           buffer.finalize

--- a/app/jobs/load_entries_from_file_job/buffer_to_store.rb
+++ b/app/jobs/load_entries_from_file_job/buffer_to_store.rb
@@ -2,9 +2,8 @@ class LoadEntriesFromFileJob::BufferToStore
   BUFFER_SIZE = 10000
 
   def initialize(dictionary)
-    @dictionary = dictionary
     @entries = []
-    @analyzer = BatchAnalyzer.new
+    @analyzer = BatchAnalyzer.new(dictionary)
   end
 
   def add_entry(label, identifier, tags)
@@ -20,11 +19,7 @@ class LoadEntriesFromFileJob::BufferToStore
   private
 
   def flush_entries
-    labels = @entries.map(&:first)
-    norm1list, norm2list = @analyzer.normalize(labels,
-                                               @dictionary.normalizer1,
-                                               @dictionary.normalizer2)
-    @dictionary.add_entries(@entries, norm1list, norm2list)
+    @analyzer.add_entries(@entries)
     @entries.clear
   rescue => e
     raise ArgumentError, "Entries are rejected: #{e.message} #{e.backtrace.join("\n")}."

--- a/app/jobs/load_entries_from_file_job/buffer_to_store.rb
+++ b/app/jobs/load_entries_from_file_job/buffer_to_store.rb
@@ -14,7 +14,7 @@ class LoadEntriesFromFileJob::BufferToStore
 
   def finalize
     flush_entries unless @entries.empty?
-    @analyzer&.shutdown
+    @analyzer.shutdown
   end
 
   private

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -675,10 +675,6 @@ class Dictionary < ApplicationRecord
     analyzer.normalize(text, normalizer2)
   end
 
-  def self.normalize2(text, analyzer = Analyzer.new)
-    analyzer.normalize(text, 'normalizer2')
-  end
-
   def language_suffix
     @language_suffix ||= if language.present?
       case language


### PR DESCRIPTION
## 概要
指定された内容のリファクタリングを行いました。

## 行ったこと
- 使用されていないメソッドの削除 (Dictionary.normalize2)
  - https://github.com/pubannotation/pubdictionaries/commit/7dae299ac82ec5fb9e9ab849c00ef74d0d1f8907
- 不要な&演算子の削除
  - https://github.com/pubannotation/pubdictionaries/commit/a0192871f6268911b12aaefc4fb9c48caf6dd404
- BufferToStore#flush_entriesのリファクタリング
  - https://github.com/pubannotation/pubdictionaries/commit/07485bfb358e9f91e83a092c412c1ed99ad7f51b
- LoadEntriesFromFileJob#perform内の不要な`nil`チェックを削除
  - https://github.com/pubannotation/pubdictionaries/commit/36f9da4f7f9f0828186ea6f29b40385d2f604bbb
- エラー処理を例外に変更
  - https://github.com/pubannotation/pubdictionaries/commit/fc4d87b411bee5689138b4490821e39840d430e1

## 動作確認
### バルクアップロード機能が問題なく動作する
|<img width="481" alt="image" src="https://github.com/user-attachments/assets/bdaa4588-5177-4089-837e-9cf2df5df7c3">|
|:-|

|<img width="1048" alt="image" src="https://github.com/user-attachments/assets/f9a3cdfc-2e37-4917-b796-68fe95e15dde">|
|:-|

<details>
<summary>インスタンス情報 (normalize処理の確認 okでした)</summary>

```
irb(main):001> Dictionary.first.entries
  Dictionary Load (2.2ms)  SELECT "dictionaries".* FROM "dictionaries" ORDER BY "dictionaries"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Entry Load (0.4ms)  SELECT "entries".* FROM "entries" WHERE "entries"."dictionary_id" = $1  [["dictionary_id", 1]]
=>
[#<Entry:0x00007ffff4f2bfd8
  id: 1340432,
  mode: 0,
  label: "abc def",
  norm1: "abcdef",
  norm2: "abcdef",
  label_length: 7,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  updated_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff4f6df28
  id: 1340433,
  mode: 0,
  label: "of",
  norm1: "of",
  norm2: "",
  label_length: 2,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  updated_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff54ea320
  id: 1340434,
  mode: 0,
  label: "hig",
  norm1: "hig",
  norm2: "hig",
  label_length: 3,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  updated_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  dirty: false,
  score: nil>]
```

</details>

### 変更した例外が適切に処理される
|<img width="736" alt="image" src="https://github.com/user-attachments/assets/00252727-cff3-4d33-a907-604e74c85c51">|
|:-|