### PR TITLE
LoadEntriesFromFileJobの高速化とリファクタリング

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -248,15 +248,12 @@ class Dictionary < ApplicationRecord
     # black_count = raw_entries.count{|e| e[2] == EntryMode::BLACK}
 
     transaction do
-      # import tags
       tag_set = raw_entries.map{|(_, _, tags)| tags}.flatten.uniq
       new_tags = tag_set - tags.where(value: tag_set).pluck(:value)
+
+      # import tags, entries, entry_tag associations
       import_tags!(new_tags) if new_tags.present?
-
-      # import entries
       entries_result = import_entries!(raw_entries, norm1list, norm2list)
-
-      # import entry_tags association
       import_entry_tags!(tag_set, entries_result, raw_entries)
 
       update_entries_num

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -264,8 +264,9 @@ class Dictionary < ApplicationRecord
       raise "Error during import of entries" unless r1.failed_instances.empty?
 
       tag_ids = {}
-      tags_uniq = entry_i_tags.map {|entry_num, tag| tag}.uniq
-      tags_uniq.each {|tag| tag_ids[tag] = Tag.find_by(dictionary_id: id, value: tag)&.id}
+      uniq_tags = entry_i_tags.map { |_, tag| tag }.uniq
+      existing_tags = tags.where(value: uniq_tags).pluck(:value, :id).to_h
+      uniq_tags.each { |tag| tag_ids[tag] = existing_tags[tag] }
 
       tags_new = tag_ids.select { |_, v| v.nil? || v == '' }.keys
 


### PR DESCRIPTION
## 概要
LoadEntriesFromFileJobの高速化とリファクタリングを行いました。

## 行ったこと
- タグ検索の改善
- Dictionary#add_entriesのリファクタリング(中島さんの案が動作したのでコピペさせてもらいました :pray: )
-  Dictionary#add_entriesの処理をメソッド分割

## 動作確認
### バルクアップロード機能が動作する
|<img width="408" alt="image" src="https://github.com/user-attachments/assets/abb02b33-873f-41c5-bb77-7a5873803e67">|
|:-|

|<img width="1038" alt="image" src="https://github.com/user-attachments/assets/7a49db8b-12e3-4a0e-9114-32ae1bde2f38">|
|:-|

<details>
<summary>インスタンス情報 (normalize処理の確認 okでした)</summary>

```
irb(main):001> Dictionary.first.entries
  Dictionary Load (2.2ms)  SELECT "dictionaries".* FROM "dictionaries" ORDER BY "dictionaries"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Entry Load (0.4ms)  SELECT "entries".* FROM "entries" WHERE "entries"."dictionary_id" = $1  [["dictionary_id", 1]]
=>
[#<Entry:0x00007ffff4f2bfd8
  id: 1340432,
  mode: 0,
  label: "abc def",
  norm1: "abcdef",
  norm2: "abcdef",
  label_length: 7,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  updated_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff4f6df28
  id: 1340433,
  mode: 0,
  label: "of",
  norm1: "of",
  norm2: "",
  label_length: 2,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  updated_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff54ea320
  id: 1340434,
  mode: 0,
  label: "hig",
  norm1: "hig",
  norm2: "hig",
  label_length: 3,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  updated_at: Thu, 26 Sep 2024 04:45:48.503462000 UTC +00:00,
  dirty: false,
  score: nil>]
```

</details>

### タグ検索の改善による影響
1万種類のタグを持つ1万件のデータで改善前と改善後の実行速度を比較します。

```
改善前：
改善後：
```