### PR TITLE
バルクアップロード処理のnormalize不具合を修正

### DIFF
--- a/app/models/batch_analyzer.rb
+++ b/app/models/batch_analyzer.rb
@@ -65,8 +65,8 @@ class BatchAnalyzer
                        [result, previous_position]
                      end.first
 
-      # Skip judgment by position value cannot determine if the last text was skipped.
-      # If the last text is skipped, add an empty string to avoid last result becomes nil.
+      # Skip judgment by position value cannot determine if the last texts were skipped.
+      # If the last texts are skipped, add empty strings to avoid last result becomes nil.
       result << '' while result.size < texts.size
 
       result

--- a/app/models/batch_analyzer.rb
+++ b/app/models/batch_analyzer.rb
@@ -65,7 +65,7 @@ class BatchAnalyzer
                        [result, previous_position]
                      end.first
 
-      # Skip judgment by postiion value cannot determine if the last text was skipped.
+      # Skip judgment by position value cannot determine if the last text was skipped.
       # If the last text is skipped, add an empty string to avoid last result becomes nil.
       result << '' if result.size == (texts.size - 1)
 

--- a/app/models/batch_analyzer.rb
+++ b/app/models/batch_analyzer.rb
@@ -67,7 +67,7 @@ class BatchAnalyzer
 
       # Skip judgment by position value cannot determine if the last text was skipped.
       # If the last text is skipped, add an empty string to avoid last result becomes nil.
-      result << '' if result.size == (texts.size - 1)
+      result << '' while result.size < texts.size
 
       result
     end


### PR DESCRIPTION
## 概要
バルクアップロード処理において、最後のラベルが全スキップされるとnorm2の最後が期待する`""`ではなく`nil`になってしまう問題がありました。
この問題を修正しました。

## 修正内容
- BatchAnalyzer#normalizeに、数が足りない分を""で埋める処理を追加

## 動作確認
### テストデータ
```
abc def	id1
hig	id2
of	id3
of of	id4
```

### 結果
```
irb(main):001> Dictionary.first.entries
  Dictionary Load (2.2ms)  SELECT "dictionaries".* FROM "dictionaries" ORDER BY "dictionaries"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Entry Load (0.7ms)  SELECT "entries".* FROM "entries" WHERE "entries"."dictionary_id" = $1  [["dictionary_id", 1]]
=>
[#<Entry:0x00007ffff5770a68
  id: 1655909,
  mode: 0,
  label: "abc def",
  norm1: "abcdef",
  norm2: "abcdef",
  label_length: 7,
  identifier: "id1",
  dictionary_id: 1,
  created_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  updated_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff75baaa0
  id: 1655910,
  mode: 0,
  label: "hig",
  norm1: "hig",
  norm2: "hig",
  label_length: 3,
  identifier: "id2",
  dictionary_id: 1,
  created_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  updated_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff75ba960
  id: 1655911,
  mode: 0,
  label: "of",
  norm1: "of",
  norm2: "",
  label_length: 2,
  identifier: "id3",
  dictionary_id: 1,
  created_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  updated_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  dirty: false,
  score: nil>,
 #<Entry:0x00007ffff75ba8c0
  id: 1655912,
  mode: 0,
  label: "of of",
  norm1: "ofof",
  norm2: "",
  label_length: 5,
  identifier: "id4",
  dictionary_id: 1,
  created_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  updated_at: Fri, 27 Sep 2024 02:58:05.374392000 UTC +00:00,
  dirty: false,
  score: nil>]
```