### PR TITLE
Jobの進捗更新をバッファに対応する形に変更

### DIFF
--- a/app/jobs/load_entries_from_file_job/flood_gate.rb
+++ b/app/jobs/load_entries_from_file_job/flood_gate.rb
@@ -1,5 +1,5 @@
-class LoadEntriesFromFileJob::BufferToStore
-  BUFFER_SIZE = 10000
+class LoadEntriesFromFileJob::FloodGate
+  CAPACITY = 10000
 
   def initialize(dictionary)
     @entries = []
@@ -8,11 +8,20 @@ class LoadEntriesFromFileJob::BufferToStore
 
   def add_entry(label, identifier, tags)
     @entries << [label, identifier, tags]
-    flush_entries if @entries.length >= BUFFER_SIZE
+
+    if @entries.length >= CAPACITY
+      flush_entries
+       true
+    else
+      false
+    end
   end
 
   def flush
+    entries_count = @entries.size
     flush_entries unless @entries.empty?
+
+    entries_count
   end
 
   def close


### PR DESCRIPTION
## 概要
エントリー毎に行われていたJobの進捗更新を、バッファに対応する形に変更しました。

## 行なったこと
- BufferToStoreクラスをFloodGateクラスに命名変更
- Jobの進捗更新をバッファに対応する形に変更

## 動作確認
### 正常パターン
Progressの分子がバッファサイズ単位で更新されるようになりました。
|<img width="454" alt="image" src="https://github.com/user-attachments/assets/468037f8-f93f-4107-88a8-a0a274196d90">|
|:-|

最後に残った数の処理も問題なく反映されています。
|<img width="555" alt="image" src="https://github.com/user-attachments/assets/1c457636-bb63-41da-a954-3589b841c119">|
|:-|

### suspendパターン
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/5f058c3b-3260-43cb-a59e-c71ea149205c">|
|:-|