### PR TITLE
バルクアップロードのSQL改善

### DIFF
--- a/app/jobs/load_entries_from_file_job/flood_gate.rb
+++ b/app/jobs/load_entries_from_file_job/flood_gate.rb
@@ -9,6 +9,9 @@ class LoadEntriesFromFileJob::FloodGate
   def add_entry(label, identifier, tags)
     @entries << [label, identifier, tags]
 
+    # Before each batch process, check and suspend job depending on status.
+    yield if @entries.length == CAPACITY - 1
+
     if @entries.length >= CAPACITY
       flush_entries
        true

--- a/app/jobs/load_entries_from_file_job/flood_gate.rb
+++ b/app/jobs/load_entries_from_file_job/flood_gate.rb
@@ -9,12 +9,12 @@ class LoadEntriesFromFileJob::FloodGate
   def add_entry(label, identifier, tags)
     @entries << [label, identifier, tags]
 
-    # Before each batch process, check and suspend job depending on status.
-    yield if @entries.length == CAPACITY - 1
-
     if @entries.length >= CAPACITY
+      # Before each batch process, check and suspend job depending on status.
+      yield
+
       flush_entries
-       true
+      true
     else
       false
     end


### PR DESCRIPTION
## 概要
バルクアップロード機能において、Job中断機能が大量のSQLを発行していました。
バッファ単位でSQLを発行するように変更し、実行速度の向上を行いました。

## 動作確認
### 中断機能が正常に動作する
|<img width="490" alt="image" src="https://github.com/user-attachments/assets/70cdda8c-d25c-4881-b52d-83208dcf3b4f">|
|:-|

### 実行速度比較
#### 改善前
|<img width="396" alt="image" src="https://github.com/user-attachments/assets/0ae1f5d1-a5a1-4268-8e38-a1bf2a31f9e7">|
|:-|

#### 改善後
|<img width="446" alt="image" src="https://github.com/user-attachments/assets/3f755b37-34f8-4fa2-baff-1d08d6f4b94d">|
|:-|