### PR TITLE
Rails7.1への更新により発生したserialize coder設定エラーを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '~> 7.1.4'
 gem 'activerecord-import'
 
 gem 'pg'
-gem 'wice_grid', '~> 4.1', github: 'ledsun/wice_grid', branch: 'rails_7' # Grid viewer for tab-separated data view.
+gem 'wice_grid', '~> 4.1', github: 'ledsun/wice_grid', branch: 'rails_7_1' # Grid viewer for tab-separated data view.
 gem 'font-awesome-sass', '~> 6.2'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ledsun/wice_grid.git
-  revision: c9f4f9ccdbcd1aa26e6d5867a339b4ab7cd1f36c
-  branch: rails_7
+  revision: 8e08de1c28ad39369b7ce79746d8b4ceb16c37b6
+  branch: rails_7_1
   specs:
     wice_grid (4.1.0)
       coffee-rails (> 3.2)


### PR DESCRIPTION
## 概要
Rails7.1以降でserializeを使用する際にcoderを指定しないと発生するエラーを修正しました。
`ArgumentError (missing keyword: :coder If no default coder is configured, a coder must be provided to `serialize`.):`

## 動作確認
修正前はアプリにスタイルが適応されない等の不具合が出ましたが、適応されるようになりました。
|<img width="1035" alt="image" src="https://github.com/user-attachments/assets/8e43ad76-81d8-4b40-8a18-f561dd97e01a">|
|:-|