### PR TITLE
ヘルパーによるURL組み立てエラーを修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # option for url_helpers in models
+  Rails.application.routes.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,4 +96,7 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # option for url_helpers in models
+  Rails.application.routes.default_url_options[:host] = 'pubdictionaries.org'
 end


### PR DESCRIPTION
## 概要
RailsのurlヘルパーがフルURLを生成する時に、以下の箇所でArgumentErrorエラーが発生していました。
https://github.com/pubannotation/pubdictionaries/blob/67d89677a4d771a68726a5b62cde486ff65f70ee/app/models/job.rb#L38

エラー内容
`ArgumentError (Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true):`

このエラーによって、ポーリング処理を行うPubAnnotationのAutomatic annotation機能でエラーが発生していました。
対応として、エラーメッセージに従って`default_url_options`を設定することで解決しました。

## 修正内容
- development.rb/production.rbにそれぞれdefault_url_optionsを設定

現状default_url_optionsを使用するテストは無かったため、test.rbへの追加は行いませんでした。
(他に合わせて追加すべきであれば追加します。)

## 動作確認
### development環境
#### エラーを起こさずにURLが生成されるか
```
(ruby) status[:result_location]
"http://localhost:3001/annotation_results/annotation-791c9522-6f5d-448a-8be6-16937674960c.json"
```

#### 結果が取得できるか
|<img width="379" alt="image" src="https://github.com/user-attachments/assets/f498dd9a-f338-4d39-87b6-d243548c1a3c">|
|:-|

### production環境
#### エラーを起こさずにURLが生成されるか
```
(ruby) status[:result_location]
"https://pubdictionaries.org/annotation_results/annotation-31d4dc29-5f69-4194-b93b-2f21255dcc5d.json"
```

#### 結果が取得できるか
生成したURLをそのまま使うとデプロイ先のサーバーにリクエストが飛んでしまうので、URL生成後にドメインを以下のように置き換えて、ローカルで検証しました。
```
      result_location = annotation_result_url(TextAnnotator::BatchResult.new(nil, id).filename, protocol: 'http')
      uri = URI.parse(result_location)
      uri.host = 'localhost'
      uri.port = 3001
      test_url = uri.to_s
      d.merge!({result_location: test_url})
```

受け取ったURL
```
(ruby) status[:result_location]
"http://localhost:3001/annotation_results/annotation-8872ff8b-4d79-4a0e-840a-704bb69b2ca6.json"
```

結果が取得できました。
|<img width="511" alt="image" src="https://github.com/user-attachments/assets/9829b97d-dbc8-4793-859b-1f2ea8bafd55">|
|:-|