### PR TITLE
Update Gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,8 +309,7 @@ GEM
       tilt
     securerandom (0.3.1)
     select2-rails (4.0.13)
-    sidekiq (7.3.2)
-      concurrent-ruby (< 2)
+    sidekiq (7.3.4)
       connection_pool (>= 2.3.0)
       logger
       rack (>= 2.2.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    pg (1.5.8)
+    pg (1.5.9)
     power_assert (2.0.3)
     psych (5.1.2)
       stringio

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       multi_json
     erubi (1.13.0)
     execjs (2.9.1)
-    faker (3.4.2)
+    faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     faraday (2.12.0)
       faraday-net_http (>= 2.0, < 3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
     jquery-ui-rails (7.0.0)
       railties (>= 3.2.16)
     json (2.7.4)
-    jwt (2.9.1)
+    jwt (2.9.3)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (7.0.0)
       railties (>= 3.2.16)
-    json (2.7.2)
+    json (2.7.4)
     jwt (2.9.1)
       base64
     kaminari (1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
     kgio (2.11.4)
     language_list (1.2.1)
     logger (1.6.1)
-    loofah (2.23.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
-    msgpack (1.7.2)
+    msgpack (1.7.3)
     multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
     pg (1.5.9)
-    power_assert (2.0.3)
+    power_assert (2.0.4)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)


### PR DESCRIPTION
## 概要
Gemの更新を行いました。

## 更新後の`bundle outdated`
```
Gem                  Current  Latest  Requested  Groups
elasticsearch        7.17.10  8.15.0
elasticsearch-api    7.17.10  8.15.0
elasticsearch-model  7.2.1    8.0.0   >= 0       default
elasticsearch-rails  7.2.1    8.0.0   >= 0       default
execjs               2.9.1    2.10.0
nio4r                2.7.3    2.7.4
rack                 2.2.10   3.1.8
rack-protection      3.2.0    4.0.0
rack-session         1.0.2    2.0.0
rackup               1.0.1    2.1.0
```

## 更新しなかったGem
- execjs
  - 最新バージョンのCHANGELOGがない
- nio4r
  - 最新バージョンのCHANGELOGがない
- rack関連
  - メジャーバージョンのアップデートで行っていいかわからなかったので、別PRでアップデートを行いました。

## 動作確認
### サーバー起動
![image](https://github.com/user-attachments/assets/8f0b8846-af04-4291-af56-6f02d00d3e84)

### テスト
![image](https://github.com/user-attachments/assets/ad565617-98a5-4f71-b3c1-f6e770d52d14)
