### PR TITLE
Fix environment settings changed by rails update

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = true
+  # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: 'pubdictionaries.org' }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: 'test.pubdictionaries.org' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
## 概要
Railsバージョンアップによって変更された環境設定ファイルに不具合があったため、修正しました。

## 行ったこと
- config.assume_ssl設定のコメントアウト
- config.action_mailer.default_url_optionsを正しく設定

## 動作確認
production環境でdeviseが送るメールをクリックすると、デプロイ先のサーバーにリクエストが送信されることを確認しました。
![image](https://github.com/user-attachments/assets/b324341e-ba4c-47b3-a2fa-aeb1324327c8)
![image](https://github.com/user-attachments/assets/47ed2b73-ae03-4f4e-900e-c0edf7147518)
