### PR TITLE
Add entry API test

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -16,6 +16,7 @@ development:
 
 test:
   <<: *default
+  host: http://elasticsearch:9200
 
 production:
   <<: *default

--- a/test/controllers/api/v1/entries_controller_test.rb
+++ b/test/controllers/api/v1/entries_controller_test.rb
@@ -1,0 +1,184 @@
+require 'test_helper'
+require 'byebug'
+
+class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    user = users(:one)
+    user.create_access_token!
+    @access_token = user.access_token.token
+
+    @dictionary = dictionaries(:one)
+    @entry = entries(:one)
+
+    @empty_dictionary = dictionaries(:two)
+    @file = fixture_file_upload('sample_tsv_entries.tsv', 'text/tab-separated-values')
+
+    @other_users_dictionary = dictionaries(:three)
+  end
+
+  # Test #create
+  test 'should create entry' do
+    assert_difference('Entry.count', 1) do
+      post '/api/v1/entries', params: { dictionary_id: @dictionary.name, label: 'abc', identifier: '123' },
+                              headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                              as: :json
+    end
+
+    assert_response :created
+    assert_equal 'abc', Entry.last.label
+    assert_equal '123', Entry.last.identifier
+  end
+
+  test 'should return error when label is blank' do
+    post '/api/v1/entries', params: { dictionary_id: @dictionary.name, identifier: '123' },
+                            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                            as: :json
+
+    assert_response :bad_request
+    assert_includes @response.body, "A label should be supplied."
+  end
+
+  test 'should return error when identifier is blank' do
+    post '/api/v1/entries', params: { dictionary_id: @dictionary.name, label: 'abc' },
+                            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                            as: :json
+
+    assert_response :bad_request
+     assert_includes @response.body, "An identifier should be supplied."
+  end
+
+  test "should return error when entry already exists" do
+    post '/api/v1/entries', params: { dictionary_id: @dictionary.name, label: @entry.label, identifier: @entry.identifier },
+                            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                            as: :json
+
+    assert_response :conflict
+    assert_includes @response.body, "The entry ('#{@entry.label}', '#{@entry.identifier}') already exists in the dictionary."
+  end
+
+  # Test #destroy_entries
+  test 'should delete entry' do
+    assert_difference('Entry.count', -1) do
+      delete '/api/v1/entries', params: { dictionary_id: @dictionary.name, entry_id: 1 },
+                                headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                                as: :json
+    end
+
+    assert_response :ok
+  end
+
+  test 'should return error when no entry_id is present' do
+    delete '/api/v1/entries', params: { dictionary_id: @dictionary.name },
+                              headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                              as: :json
+
+    assert_response :bad_request
+    assert_includes @response.body, "No entry to be deleted is selected"
+  end
+
+  test 'should return error when entry_id does not exist' do
+    delete '/api/v1/entries', params: { dictionary_id: @dictionary.name, entry_id: 9999 },
+                              headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                              as: :json
+
+    assert_response :not_found
+    assert_includes @response.body, "Could not find the entries, 9999"
+  end
+
+  # Test #undo
+  test 'should undo entry' do
+    assert_equal EntryMode::WHITE, @entry.mode
+
+    assert_difference('Entry.count', -1) do
+      put "/api/v1/entries/#{@entry.id}/undo", params: { dictionary_id: @dictionary.name },
+                                              headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                                              as: :json
+    end
+
+    assert_response :ok
+  end
+
+  test 'should return error when entry does not exist' do
+    put "/api/v1/entries/9999/undo", params: { dictionary_id: @dictionary.name },
+                                             headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                                             as: :json
+
+    assert_response :bad_request
+    assert_includes @response.body, "Cannot find the entry."
+  end
+
+  # Test #upload_tsv
+  test 'should create bulk upload job' do
+    post '/api/v1/entries/tsv', params: { dictionary_id: @empty_dictionary.name, file: @file },
+                                headers: { 'Content-Type' => 'multipart/form-data', 'Authorization' => "Bearer #{@access_token}" }
+
+    assert_response :accepted
+  end
+
+  test 'should create bulk upload job with force option' do
+    @empty_dictionary.jobs.create!(name: 'test-job', begun_at: Time.now - 2, ended_at: Time.now - 1)
+
+    post '/api/v1/entries/tsv?force=true', params: { dictionary_id: @empty_dictionary.name, file: @file },
+                                           headers: { 'Content-Type' => 'multipart/form-data', 'Authorization' => "Bearer #{@access_token}" }
+
+    assert_response :accepted
+  end
+
+  test 'should return error when job exist' do
+    @empty_dictionary.jobs.create!(name: 'test-job', begun_at: Time.now - 2, ended_at: Time.now - 1)
+
+    post '/api/v1/entries/tsv', params: { dictionary_id: @empty_dictionary.name, file: @file },
+                                headers: { 'Content-Type' => 'multipart/form-data', 'Authorization' => "Bearer #{@access_token}" }
+
+    assert_response :conflict
+    assert_includes @response.body, "The last task is not yet dismissed. Please dismiss it and try again."
+  end
+
+  test 'should return error when dictionary is not uploadable' do
+    post '/api/v1/entries/tsv', params: { dictionary_id: @dictionary.name, file: @file },
+                                headers: { 'Content-Type' => 'multipart/form-data', 'Authorization' => "Bearer #{@access_token}" }
+
+    assert_response :bad_request
+    assert_includes @response.body, "Uploading a dictionary is only possible if there are no dictionary entries."
+  end
+
+  # Test Authentication
+  test 'should not be able to change resources without access token' do
+    post "/api/v1/entries", params: { dictionary_id: @dictionary.name, label: 'abc', identifier: '123' },
+                            headers: { 'Content-Type' => 'application/json' },
+                            as: :json
+    assert_response :unauthorized
+
+    delete '/api/v1/entries', params: { dictionary_id: @dictionary.name, entry_id: 1 },
+                              headers: { 'Content-Type' => 'application/json' },
+                              as: :json
+    assert_response :unauthorized
+
+    put "/api/v1/entries/#{@entry.id}/undo", params: { dictionary_id: @dictionary.name },
+                                             headers: { 'Content-Type' => 'application/json' },
+                                             as: :json
+    assert_response :unauthorized
+
+    post '/api/v1/entries/tsv', params: { dictionary_id: @empty_dictionary.name, file: @file },
+                                headers: { 'Content-Type' => 'multipart/form-data' }
+    assert_response :unauthorized
+  end
+
+  test 'should not be able to change resources with invalid access token' do
+    post "/api/v1/entries", params: { dictionary_id: @dictionary.name, label: 'abc', identifier: '123' },
+                            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer invalid-token" },
+                            as: :json
+
+    assert_response :unauthorized
+  end
+
+  test 'should not be able to change other users resources' do
+    post "/api/v1/entries", params: { dictionary_id: @other_users_dictionary.name, label: 'abc', identifier: '123' },
+    headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+    as: :json
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/api/v1/entries_controller_test.rb
+++ b/test/controllers/api/v1/entries_controller_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'byebug'
 
 class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers

--- a/test/controllers/api/v1/entries_controller_test.rb
+++ b/test/controllers/api/v1/entries_controller_test.rb
@@ -45,7 +45,7 @@ class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
                             as: :json
 
     assert_response :bad_request
-     assert_includes @response.body, "An identifier should be supplied."
+    assert_includes @response.body, "An identifier should be supplied."
   end
 
   test "should return error when entry already exists" do
@@ -92,8 +92,8 @@ class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
 
     assert_difference('Entry.count', -1) do
       put "/api/v1/entries/#{@entry.id}/undo", params: { dictionary_id: @dictionary.name },
-                                              headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
-                                              as: :json
+                                               headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                                               as: :json
     end
 
     assert_response :ok
@@ -101,8 +101,8 @@ class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should return error when entry does not exist' do
     put "/api/v1/entries/9999/undo", params: { dictionary_id: @dictionary.name },
-                                             headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
-                                             as: :json
+                                     headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                                     as: :json
 
     assert_response :bad_request
     assert_includes @response.body, "Cannot find the entry."
@@ -175,8 +175,8 @@ class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should not be able to change other users resources' do
     post "/api/v1/entries", params: { dictionary_id: @other_users_dictionary.name, label: 'abc', identifier: '123' },
-    headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
-    as: :json
+                            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
+                            as: :json
 
     assert_response :not_found
   end

--- a/test/controllers/api/v1/entries_controller_test.rb
+++ b/test/controllers/api/v1/entries_controller_test.rb
@@ -12,10 +12,10 @@ class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
     @dictionary = dictionaries(:one)
     @entry = entries(:one)
 
-    @empty_dictionary = dictionaries(:two)
+    @empty_dictionary = dictionaries(:empty_dictionary)
     @file = fixture_file_upload('sample_tsv_entries.tsv', 'text/tab-separated-values')
 
-    @other_users_dictionary = dictionaries(:three)
+    @other_users_dictionary = dictionaries(:two)
   end
 
   # Test #create

--- a/test/fixtures/dictionaries.yml
+++ b/test/fixtures/dictionaries.yml
@@ -6,15 +6,15 @@ one:
   entries_num: 1
 
 two:
-  id: 2
-  user_id: 1
-  name: TestDict2
-  description: TestDict2 dictionary
-  entries_num: 0
-
-three:
   id: 3
   user_id: 2
   name: TestDict3
   description: TestDict3 dictionary
+  entries_num: 0
+
+empty_dictionary:
+  id: 2
+  user_id: 1
+  name: TestDict2
+  description: TestDict2 dictionary
   entries_num: 0

--- a/test/fixtures/dictionaries.yml
+++ b/test/fixtures/dictionaries.yml
@@ -1,0 +1,20 @@
+one:
+  id: 1
+  user_id: 1
+  name: TestDict1
+  description: TestDict1 dictionary
+  entries_num: 1
+
+two:
+  id: 2
+  user_id: 1
+  name: TestDict2
+  description: TestDict2 dictionary
+  entries_num: 0
+
+three:
+  id: 3
+  user_id: 2
+  name: TestDict3
+  description: TestDict3 dictionary
+  entries_num: 0

--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -1,0 +1,10 @@
+
+one:
+  id: 1
+  mode: 1
+  label: PROTEASOME ACTIVATOR 28-BETA
+  norm1: proteasomeactivator28beta
+  norm2: proteasomactiv28beta
+  label_length: 28
+  identifier: 602161
+  dictionary_id: 1

--- a/test/fixtures/files/sample_tsv_entries.tsv
+++ b/test/fixtures/files/sample_tsv_entries.tsv
@@ -1,0 +1,4 @@
+abc def	id1
+hig	id2
+of	id3
+of of	id4

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,6 @@
+one:
+  id: 1
+  username: "test1"
+  email: "test1@example.com"
+  encrypted_password: "password"
+  confirmed_at: <%= Time.now - 100 %>


### PR DESCRIPTION
## 概要
Entry APIにテストを追加しました。

## 作業内容
- テストの追加
  - 各APIの正常系の確認
  - 各APIの異常系の確認
  - Client Credential認証の確認
- dockerでテスト環境時にElasticsearchに接続できるようにelasticsearch.ymlに設定を追加

## 実行結果
テストが2回実行されていますが、既存のテストが上の8testのもので、追加したテストは下のものです。
```
docker compose exec web rails test
Loaded suite bin/rails
Started
Finished in 0.014012375 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
8 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
570.92 tests/s, 570.92 assertions/s
Run options: --seed 29172

# Running:

.........F

Failure:
Api::V1::EntriesControllerTest#test_should_return_error_when_entry_does_not_exist [test/controllers/api/v1/entries_controller_test.rb:108]:
Expected response to be a <400: bad_request>, but was a <500: Internal Server Error>
Response body: {"error":"Couldn't find Entry with 'id'=9999"}.
Expected: 400
  Actual: 500


bin/rails test test/controllers/api/v1/entries_controller_test.rb:103

......

Finished in 0.953032s, 16.7885 runs/s, 44.0699 assertions/s.
16 runs, 42 assertions, 1 failures, 0 errors, 0 skips
```

## 失敗しているテストについて
undoメソッドで指定したIDを持つEntryがない場合に、コードでは400 bad requestを返答する想定でした。
しかし実際には、Entry.findメソッドはレコードが見つからない場合に例外を発生させるのでnilが代入されず、期待する動作になっていませんでした。
```
  def undo
    entry = Entry.find(params[:id])

    if entry.nil?
      render json: { error: "Cannot find the entry." }, status: :bad_request
      return
    end

    @dictionary.undo_entry(entry)

    render json: { message: "Entry was successfully undid." }, status: :ok
  end
```

こちらについてはRedの状態が正しいので、エラーはそのままとして別で対応しようと思います。