### PR TITLE
Fix entry undo API error handling

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -49,7 +49,7 @@ class Api::V1::EntriesController < ApplicationController
   end
 
   def undo
-    entry = Entry.find(params[:id])
+    entry = Entry.find_by(id: params[:id])
 
     if entry.nil?
       render json: { error: "Cannot find the entry." }, status: :bad_request


### PR DESCRIPTION
## 概要
Entry undo APIで指定のEntryが見つからない場合の例外処理が正しく行われていない問題を修正しました。

## 動作確認
期待するレスポンスが返ることを確認しました。
```
curl -X PUT http://localhost:3000/api/v1/entries/123/undo \
-H "Authorization: Bearer 4009b610fe42472dda6ab8e49d1704d8" \
  -H "Content-Type: application/json" \
  -d '{
       "dictionary_id": "EntrezGene"
     }'
{"error":"Cannot find the entry."}%
```