### PR TITLE
Fix entry undo API error response code

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::EntriesController < ApplicationController
     entry = Entry.find_by(id: params[:id])
 
     if entry.nil?
-      render json: { error: "Cannot find the entry." }, status: :bad_request
+      render json: { error: "Cannot find the entry." }, status: :not_found
       return
     end
 

--- a/test/controllers/api/v1/entries_controller_test.rb
+++ b/test/controllers/api/v1/entries_controller_test.rb
@@ -104,7 +104,7 @@ class Api::V1::EntriesControllerTest < ActionDispatch::IntegrationTest
                                      headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{@access_token}" },
                                      as: :json
 
-    assert_response :bad_request
+    assert_response :not_found
     assert_includes @response.body, "Cannot find the entry."
   end
 


### PR DESCRIPTION
## 概要
Entry undo APIで指定したIDが見つからなかった場合に400 bad requestが返っていました。
リクエストされたリソースを見つけることができない場合は404 not foundの方が適しているため、404を返すように修正しました。

## テスト結果
```
docker compose exec web rails test
Loaded suite bin/rails
Started
Finished in 0.013593084 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
8 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
588.53 tests/s, 588.53 assertions/s
Run options: --seed 39988

# Running:

................

Finished in 1.039475s, 15.3924 runs/s, 42.3291 assertions/s.
16 runs, 44 assertions, 0 failures, 0 errors, 0 skips
```