### PR TITLE
Fix cannot start server in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4.1
+FROM ruby:3.4.2
 
 ENV BUILD_PACKAGES="ruby-dev bash less" \
     DEV_PACKAGES="libxml2-dev libxslt-dev tzdata swig" \

--- a/compose.yml
+++ b/compose.yml
@@ -13,7 +13,7 @@ services:
 
   db:
     platform: linux/amd64
-    image: postgres
+    image: ankane/pgvector
     environment:
       POSTGRES_PASSWORD: password
       PGPASSWORD: password


### PR DESCRIPTION
## 概要
Dockerでサーバーが起動できない問題を修正しました。

## 作業内容
- DockerfileのRuby versionを更新
- Docker内でPostgreSQL vector拡張機能に対応しているDBを使用するように変更

## 動作確認
サーバーが起動できることを確認
```
web-1            | => Booting WEBrick
web-1            | => Rails 8.0.1 application starting in development http://0.0.0.0:3000
web-1            | => Run `bin/rails server --help` for more startup options
web-1            | [2025-03-25 02:36:52] INFO  WEBrick 1.9.1
web-1            | [2025-03-25 02:36:52] INFO  ruby 3.4.2 (2025-02-15) [x86_64-linux]
web-1            | [2025-03-25 02:36:52] INFO  WEBrick::HTTPServer#start: pid=19 port=3000
```